### PR TITLE
rewrite ToGraph with gographviz

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/qmuntal/stateless
 
 go 1.13
 
-require github.com/stretchr/testify v1.4.0
+require (
+	github.com/awalterschulze/gographviz v2.0.3+incompatible
+	github.com/stretchr/testify v1.4.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/awalterschulze/gographviz v2.0.3+incompatible h1:9sVEXJBJLwGX7EQVhLm2elIKCm7P2YHFC8v6096G09E=
+github.com/awalterschulze/gographviz v2.0.3+incompatible/go.mod h1:GEV5wmg4YquNw7v1kkyoX9etIk8yVmXj+AkDHuuETHs=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/statemachine.go
+++ b/statemachine.go
@@ -116,7 +116,7 @@ func NewStateMachineWithExternalStorage(stateAccessor func(context.Context) (Sta
 // ToGraph returns the DOT representation of the state machine.
 // It is not guaranteed that the returned string will be the same in different executions.
 func (sm *StateMachine) ToGraph() string {
-	return new(graph).FormatStateMachine(sm)
+	return newGraph().FormatStateMachine(sm)
 }
 
 // State returns the current state.


### PR DESCRIPTION
close #21 
I use gographviz to refactor ToGraph function
features:
+ multi level sub state
+ InitialState
+ escape string

example code
```golang
package main

import (
	"context"
	"fmt"

	"github.com/qmuntal/stateless"
)

func main() {
	sm := stateless.NewStateMachine("a")
	sm.Configure("a").Permit("toB", "b").OnEntry(func(ctx context.Context, i ...interface{}) error {
		return nil
	})
	sm.Configure("b").InitialTransition("b_1").OnExit(func(ctx context.Context, i ...interface{}) error {
		return nil
	}).Permit("toC", "c")
	sm.Configure("b_1").SubstateOf("b").InitialTransition("b_1_1").Permit("toB2", "b_2")
	sm.Configure("b_2").SubstateOf("b")
	sm.Configure("b_1_1").SubstateOf("b_1")
	fmt.Println(sm.ToGraph())
}

```

exmaple output
```dot
digraph stateless {
	compound=true;
	rankdir=LR;
	"cluster_b_1-init"->b_1_1;
	"cluster_b-init"->"cluster_b_1-init"[ lhead=cluster_b_1 ];
	a->b_1_1[ label=toB, lhead=cluster_b ];
	b_1_1->c[ label=toC, ltail=cluster_b ];
	b_1_1->b_2[ label=toB2, ltail=cluster_b_1 ];
	"stateless-init"->a;
	subgraph cluster_b {
	label="b
----------
exit / func2";
	"cluster_b-init" [ label=init, shape=point ];
	b_2 [ label=b_2, shape=Mrecord ];
	subgraph cluster_b_1 {
	label=b_1;
	"cluster_b_1-init" [ label=init, shape=point ];
	b_1_1 [ label=b_1_1, shape=Mrecord ];

}
;

}
;
	"stateless-init" [ label=init, shape=point ];
	a [ label="a|entry / func1", shape=Mrecord ];
	c;

}
```
![image](https://user-images.githubusercontent.com/3352585/115437097-56087900-a23e-11eb-8b9d-4d917cef506b.png)
