### PR TITLE
Test passing state and trigger as generic types

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.13.x, 1.14.x, 1.15.x]
+        go-version: [1.18.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@
 
 # Stateless
 
-**Create *state machines* and lightweight *state machine-based workflows* directly in Go code:**
+**Create _state machines_ and lightweight _state machine-based workflows_ directly in Go code:**
 
 ```go
-phoneCall := stateless.NewStateMachine(stateOffHook)
+phoneCall := stateless.NewStateMachine[string, string](stateOffHook)
 
 phoneCall.Configure(stateOffHook).Permit(triggerCallDialed, stateRinging)
 
@@ -50,19 +50,19 @@ The state machine implemented in this library is based on the theory of [UML sta
 
 Most standard state machine constructs are supported:
 
-* Support for states and triggers of any comparable type (int, strings, boolean, structs, etc.)
-* Hierarchical states
-* Entry/exit events for states
-* Guard clauses to support conditional transitions
-* Introspection
+- Support for states and triggers of any comparable type (int, strings, boolean, structs, etc.)
+- Hierarchical states
+- Entry/exit events for states
+- Guard clauses to support conditional transitions
+- Introspection
 
 Some useful extensions are also provided:
 
-* Ability to store state externally (for example, in a property tracked by an ORM)
-* Parameterised triggers
-* Reentrant states
-* Thread-safe
-* Export to DOT graph
+- Ability to store state externally (for example, in a property tracked by an ORM)
+- Parameterised triggers
+- Reentrant states
+- Thread-safe
+- Export to DOT graph
 
 ### Hierarchical States
 
@@ -102,9 +102,9 @@ sm.Configure(State.C)
 Stateless is designed to be embedded in various application models. For example, some ORMs place requirements upon where mapped data may be stored, and UI frameworks often require state to be stored in special "bindable" properties. To this end, the `StateMachine` constructor can accept function arguments that will be used to read and write the state values:
 
 ```go
-machine := stateless.NewStateMachineWithExternalStorage(func(_ context.Context) (stateless.State, error) {
+machine := stateless.NewStateMachineWithExternalStorage[string, string](func(_ context.Context) (string, error) {
   return myState.Value, nil
-}, func(_ context.Context, state stateless.State) error {
+}, func(_ context.Context, state string) error {
   myState.Value  = state
   return nil
 }, stateless.FiringQueued)
@@ -208,7 +208,7 @@ This can then be rendered by tools that support the DOT graph language, such as 
 
 This is the complete Phone Call graph as builded in `example_test.go`.
 
-![Phone Call graph](assets/phone-graph.png?raw=true "Phone Call complete DOT")
+![Phone Call graph](assets/phone-graph.png?raw=true 'Phone Call complete DOT')
 
 ## Project Goals
 

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ type StateConfiguration[S State, T Trigger] struct {
 }
 
 // State is configured with this configuration.
-func (sc *StateConfiguration[S, T]) State() S {
+func (sc *StateConfiguration[S, _]) State() S {
 	return sc.sr.State
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -29,7 +29,7 @@ const (
 )
 
 func Example() {
-	phoneCall := stateless.NewStateMachine(stateOffHook)
+	phoneCall := stateless.NewStateMachine[string, string](stateOffHook)
 	phoneCall.SetTriggerParameters(triggerSetVolume, reflect.TypeOf(0))
 	phoneCall.SetTriggerParameters(triggerCallDialed, reflect.TypeOf(""))
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,11 @@
 module github.com/qmuntal/stateless
 
-go 1.13
+go 1.18
 
 require github.com/stretchr/testify v1.4.0
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
+)

--- a/states.go
+++ b/states.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 )
 
-type actionBehaviour struct {
+type actionBehaviour[S State, T Trigger] struct {
 	Action      ActionFunc
 	Description invocationInfo
-	Trigger     *Trigger
+	Trigger     *T
 }
 
-func (a actionBehaviour) Execute(ctx context.Context, transition Transition, args ...interface{}) (err error) {
+func (a actionBehaviour[S, T]) Execute(ctx context.Context, transition Transition[S, T], args ...interface{}) (err error) {
 	if a.Trigger == nil || *a.Trigger == transition.Trigger {
 		ctx = withTransition(ctx, transition)
 		err = a.Action(ctx, args...)
@@ -28,41 +28,41 @@ func (a actionBehaviourSteady) Execute(ctx context.Context) error {
 	return a.Action(ctx)
 }
 
-type stateRepresentation struct {
-	State                   State
-	InitialTransitionTarget State
-	Superstate              *stateRepresentation
-	EntryActions            []actionBehaviour
-	ExitActions             []actionBehaviour
+type stateRepresentation[S State, T Trigger] struct {
+	State                   S
+	InitialTransitionTarget S
+	Superstate              *stateRepresentation[S, T]
+	EntryActions            []actionBehaviour[S, T]
+	ExitActions             []actionBehaviour[S, T]
 	ActivateActions         []actionBehaviourSteady
 	DeactivateActions       []actionBehaviourSteady
-	Substates               []*stateRepresentation
-	TriggerBehaviours       map[Trigger][]triggerBehaviour
+	Substates               []*stateRepresentation[S, T]
+	TriggerBehaviours       map[T][]triggerBehaviour[T]
 	HasInitialState         bool
 }
 
-func newstateRepresentation(state State) *stateRepresentation {
-	return &stateRepresentation{
+func newstateRepresentation[S State, T Trigger](state S) *stateRepresentation[S, T] {
+	return &stateRepresentation[S, T]{
 		State:             state,
-		TriggerBehaviours: make(map[Trigger][]triggerBehaviour),
+		TriggerBehaviours: make(map[T][]triggerBehaviour[T]),
 	}
 }
 
-func (sr *stateRepresentation) SetInitialTransition(state State) {
+func (sr *stateRepresentation[S, T]) SetInitialTransition(state S) {
 	sr.InitialTransitionTarget = state
 	sr.HasInitialState = true
 }
 
-func (sr *stateRepresentation) state() State {
+func (sr *stateRepresentation[S, T]) state() S {
 	return sr.State
 }
 
-func (sr *stateRepresentation) CanHandle(ctx context.Context, trigger Trigger, args ...interface{}) (ok bool) {
+func (sr *stateRepresentation[S, T]) CanHandle(ctx context.Context, trigger T, args ...interface{}) (ok bool) {
 	_, ok = sr.FindHandler(ctx, trigger, args...)
 	return
 }
 
-func (sr *stateRepresentation) FindHandler(ctx context.Context, trigger Trigger, args ...interface{}) (handler triggerBehaviourResult, ok bool) {
+func (sr *stateRepresentation[S, T]) FindHandler(ctx context.Context, trigger T, args ...interface{}) (handler triggerBehaviourResult[T], ok bool) {
 	handler, ok = sr.findHandler(ctx, trigger, args...)
 	if ok || sr.Superstate == nil {
 		return
@@ -71,22 +71,22 @@ func (sr *stateRepresentation) FindHandler(ctx context.Context, trigger Trigger,
 	return
 }
 
-func (sr *stateRepresentation) findHandler(ctx context.Context, trigger Trigger, args ...interface{}) (result triggerBehaviourResult, ok bool) {
+func (sr *stateRepresentation[S, T]) findHandler(ctx context.Context, trigger T, args ...interface{}) (result triggerBehaviourResult[T], ok bool) {
 	var (
-		possibleBehaviours []triggerBehaviour
+		possibleBehaviours []triggerBehaviour[T]
 	)
 	if possibleBehaviours, ok = sr.TriggerBehaviours[trigger]; !ok {
 		return
 	}
-	allResults := make([]triggerBehaviourResult, 0, len(possibleBehaviours))
+	allResults := make([]triggerBehaviourResult[T], 0, len(possibleBehaviours))
 	for _, behaviour := range possibleBehaviours {
-		allResults = append(allResults, triggerBehaviourResult{
+		allResults = append(allResults, triggerBehaviourResult[T]{
 			Handler:              behaviour,
 			UnmetGuardConditions: behaviour.UnmetGuardConditions(ctx, args...),
 		})
 	}
-	metResults := make([]triggerBehaviourResult, 0, len(allResults))
-	unmetResults := make([]triggerBehaviourResult, 0, len(allResults))
+	metResults := make([]triggerBehaviourResult[T], 0, len(allResults))
+	unmetResults := make([]triggerBehaviourResult[T], 0, len(allResults))
 	for _, result := range allResults {
 		if len(result.UnmetGuardConditions) == 0 {
 			metResults = append(metResults, result)
@@ -105,7 +105,7 @@ func (sr *stateRepresentation) findHandler(ctx context.Context, trigger Trigger,
 	return
 }
 
-func (sr *stateRepresentation) Activate(ctx context.Context) error {
+func (sr *stateRepresentation[S, T]) Activate(ctx context.Context) error {
 	if sr.Superstate != nil {
 		if err := sr.Superstate.Activate(ctx); err != nil {
 			return err
@@ -114,7 +114,7 @@ func (sr *stateRepresentation) Activate(ctx context.Context) error {
 	return sr.executeActivationActions(ctx)
 }
 
-func (sr *stateRepresentation) Deactivate(ctx context.Context) error {
+func (sr *stateRepresentation[S, T]) Deactivate(ctx context.Context) error {
 	if err := sr.executeDeactivationActions(ctx); err != nil {
 		return err
 	}
@@ -124,7 +124,7 @@ func (sr *stateRepresentation) Deactivate(ctx context.Context) error {
 	return nil
 }
 
-func (sr *stateRepresentation) Enter(ctx context.Context, transition Transition, args ...interface{}) error {
+func (sr *stateRepresentation[S, T]) Enter(ctx context.Context, transition Transition[S, T], args ...interface{}) error {
 	if transition.IsReentry() {
 		return sr.executeEntryActions(ctx, transition, args...)
 	}
@@ -139,7 +139,7 @@ func (sr *stateRepresentation) Enter(ctx context.Context, transition Transition,
 	return sr.executeEntryActions(ctx, transition, args...)
 }
 
-func (sr *stateRepresentation) Exit(ctx context.Context, transition Transition, args ...interface{}) (err error) {
+func (sr *stateRepresentation[S, T]) Exit(ctx context.Context, transition Transition[S, T], args ...interface{}) (err error) {
 	isReentry := transition.IsReentry()
 	if !isReentry && sr.IncludeState(transition.Destination) {
 		return
@@ -162,13 +162,13 @@ func (sr *stateRepresentation) Exit(ctx context.Context, transition Transition, 
 	return
 }
 
-func (sr *stateRepresentation) InternalAction(ctx context.Context, transition Transition, args ...interface{}) error {
-	var internalTransition *internalTriggerBehaviour
-	var stateRep *stateRepresentation = sr
+func (sr *stateRepresentation[S, T]) InternalAction(ctx context.Context, transition Transition[S, T], args ...interface{}) error {
+	var internalTransition *internalTriggerBehaviour[S, T]
+	var stateRep *stateRepresentation[S, T] = sr
 	for stateRep != nil {
 		if result, ok := stateRep.findHandler(ctx, transition.Trigger, args...); ok {
 			switch t := result.Handler.(type) {
-			case *internalTriggerBehaviour:
+			case *internalTriggerBehaviour[S, T]:
 				internalTransition = t
 			}
 			break
@@ -181,7 +181,7 @@ func (sr *stateRepresentation) InternalAction(ctx context.Context, transition Tr
 	return internalTransition.Execute(ctx, transition, args...)
 }
 
-func (sr *stateRepresentation) IncludeState(state State) bool {
+func (sr *stateRepresentation[S, T]) IncludeState(state S) bool {
 	if state == sr.State {
 		return true
 	}
@@ -193,7 +193,7 @@ func (sr *stateRepresentation) IncludeState(state State) bool {
 	return false
 }
 
-func (sr *stateRepresentation) IsIncludedInState(state State) bool {
+func (sr *stateRepresentation[S, T]) IsIncludedInState(state S) bool {
 	if state == sr.State {
 		return true
 	}
@@ -203,13 +203,13 @@ func (sr *stateRepresentation) IsIncludedInState(state State) bool {
 	return false
 }
 
-func (sr *stateRepresentation) AddTriggerBehaviour(tb triggerBehaviour) {
+func (sr *stateRepresentation[S, T]) AddTriggerBehaviour(tb triggerBehaviour[T]) {
 	trigger := tb.GetTrigger()
 	sr.TriggerBehaviours[trigger] = append(sr.TriggerBehaviours[trigger], tb)
 
 }
 
-func (sr *stateRepresentation) PermittedTriggers(ctx context.Context, args ...interface{}) (triggers []Trigger) {
+func (sr *stateRepresentation[S, T]) PermittedTriggers(ctx context.Context, args ...interface{}) (triggers []T) {
 	for key, value := range sr.TriggerBehaviours {
 		for _, tb := range value {
 			if len(tb.UnmetGuardConditions(ctx, args...)) == 0 {
@@ -221,7 +221,7 @@ func (sr *stateRepresentation) PermittedTriggers(ctx context.Context, args ...in
 	if sr.Superstate != nil {
 		triggers = append(triggers, sr.Superstate.PermittedTriggers(ctx, args...)...)
 		// remove duplicated
-		seen := make(map[Trigger]struct{}, len(triggers))
+		seen := make(map[T]struct{}, len(triggers))
 		j := 0
 		for _, v := range triggers {
 			if _, ok := seen[v]; ok {
@@ -236,7 +236,7 @@ func (sr *stateRepresentation) PermittedTriggers(ctx context.Context, args ...in
 	return
 }
 
-func (sr *stateRepresentation) executeActivationActions(ctx context.Context) error {
+func (sr *stateRepresentation[S, T]) executeActivationActions(ctx context.Context) error {
 	for _, a := range sr.ActivateActions {
 		if err := a.Execute(ctx); err != nil {
 			return err
@@ -245,7 +245,7 @@ func (sr *stateRepresentation) executeActivationActions(ctx context.Context) err
 	return nil
 }
 
-func (sr *stateRepresentation) executeDeactivationActions(ctx context.Context) error {
+func (sr *stateRepresentation[S, T]) executeDeactivationActions(ctx context.Context) error {
 	for _, a := range sr.DeactivateActions {
 		if err := a.Execute(ctx); err != nil {
 			return err
@@ -254,7 +254,7 @@ func (sr *stateRepresentation) executeDeactivationActions(ctx context.Context) e
 	return nil
 }
 
-func (sr *stateRepresentation) executeEntryActions(ctx context.Context, transition Transition, args ...interface{}) error {
+func (sr *stateRepresentation[S, T]) executeEntryActions(ctx context.Context, transition Transition[S, T], args ...interface{}) error {
 	for _, a := range sr.EntryActions {
 		if err := a.Execute(ctx, transition, args...); err != nil {
 			return err
@@ -263,7 +263,7 @@ func (sr *stateRepresentation) executeEntryActions(ctx context.Context, transiti
 	return nil
 }
 
-func (sr *stateRepresentation) executeExitActions(ctx context.Context, transition Transition, args ...interface{}) error {
+func (sr *stateRepresentation[S, T]) executeExitActions(ctx context.Context, transition Transition[S, T], args ...interface{}) error {
 	for _, a := range sr.ExitActions {
 		if err := a.Execute(ctx, transition, args...); err != nil {
 			return err

--- a/states.go
+++ b/states.go
@@ -206,7 +206,6 @@ func (sr *stateRepresentation[S, T]) IsIncludedInState(state S) bool {
 func (sr *stateRepresentation[S, T]) AddTriggerBehaviour(tb triggerBehaviour[T]) {
 	trigger := tb.GetTrigger()
 	sr.TriggerBehaviours[trigger] = append(sr.TriggerBehaviours[trigger], tb)
-
 }
 
 func (sr *stateRepresentation[S, T]) PermittedTriggers(ctx context.Context, args ...interface{}) (triggers []T) {

--- a/states.go
+++ b/states.go
@@ -48,21 +48,21 @@ func newstateRepresentation[S State, T Trigger](state S) *stateRepresentation[S,
 	}
 }
 
-func (sr *stateRepresentation[S, T]) SetInitialTransition(state S) {
+func (sr *stateRepresentation[S, _]) SetInitialTransition(state S) {
 	sr.InitialTransitionTarget = state
 	sr.HasInitialState = true
 }
 
-func (sr *stateRepresentation[S, T]) state() S {
+func (sr *stateRepresentation[S, _]) state() S {
 	return sr.State
 }
 
-func (sr *stateRepresentation[S, T]) CanHandle(ctx context.Context, trigger T, args ...interface{}) (ok bool) {
+func (sr *stateRepresentation[_, T]) CanHandle(ctx context.Context, trigger T, args ...interface{}) (ok bool) {
 	_, ok = sr.FindHandler(ctx, trigger, args...)
 	return
 }
 
-func (sr *stateRepresentation[S, T]) FindHandler(ctx context.Context, trigger T, args ...interface{}) (handler triggerBehaviourResult[T], ok bool) {
+func (sr *stateRepresentation[_, T]) FindHandler(ctx context.Context, trigger T, args ...interface{}) (handler triggerBehaviourResult[T], ok bool) {
 	handler, ok = sr.findHandler(ctx, trigger, args...)
 	if ok || sr.Superstate == nil {
 		return
@@ -71,7 +71,7 @@ func (sr *stateRepresentation[S, T]) FindHandler(ctx context.Context, trigger T,
 	return
 }
 
-func (sr *stateRepresentation[S, T]) findHandler(ctx context.Context, trigger T, args ...interface{}) (result triggerBehaviourResult[T], ok bool) {
+func (sr *stateRepresentation[_, T]) findHandler(ctx context.Context, trigger T, args ...interface{}) (result triggerBehaviourResult[T], ok bool) {
 	var (
 		possibleBehaviours []triggerBehaviour[T]
 	)
@@ -105,7 +105,7 @@ func (sr *stateRepresentation[S, T]) findHandler(ctx context.Context, trigger T,
 	return
 }
 
-func (sr *stateRepresentation[S, T]) Activate(ctx context.Context) error {
+func (sr *stateRepresentation[_, _]) Activate(ctx context.Context) error {
 	if sr.Superstate != nil {
 		if err := sr.Superstate.Activate(ctx); err != nil {
 			return err
@@ -114,7 +114,7 @@ func (sr *stateRepresentation[S, T]) Activate(ctx context.Context) error {
 	return sr.executeActivationActions(ctx)
 }
 
-func (sr *stateRepresentation[S, T]) Deactivate(ctx context.Context) error {
+func (sr *stateRepresentation[_, _]) Deactivate(ctx context.Context) error {
 	if err := sr.executeDeactivationActions(ctx); err != nil {
 		return err
 	}
@@ -181,7 +181,7 @@ func (sr *stateRepresentation[S, T]) InternalAction(ctx context.Context, transit
 	return internalTransition.Execute(ctx, transition, args...)
 }
 
-func (sr *stateRepresentation[S, T]) IncludeState(state S) bool {
+func (sr *stateRepresentation[S, _]) IncludeState(state S) bool {
 	if state == sr.State {
 		return true
 	}
@@ -193,7 +193,7 @@ func (sr *stateRepresentation[S, T]) IncludeState(state S) bool {
 	return false
 }
 
-func (sr *stateRepresentation[S, T]) IsIncludedInState(state S) bool {
+func (sr *stateRepresentation[S, _]) IsIncludedInState(state S) bool {
 	if state == sr.State {
 		return true
 	}
@@ -203,12 +203,12 @@ func (sr *stateRepresentation[S, T]) IsIncludedInState(state S) bool {
 	return false
 }
 
-func (sr *stateRepresentation[S, T]) AddTriggerBehaviour(tb triggerBehaviour[T]) {
+func (sr *stateRepresentation[_, T]) AddTriggerBehaviour(tb triggerBehaviour[T]) {
 	trigger := tb.GetTrigger()
 	sr.TriggerBehaviours[trigger] = append(sr.TriggerBehaviours[trigger], tb)
 }
 
-func (sr *stateRepresentation[S, T]) PermittedTriggers(ctx context.Context, args ...interface{}) (triggers []T) {
+func (sr *stateRepresentation[_, T]) PermittedTriggers(ctx context.Context, args ...interface{}) (triggers []T) {
 	for key, value := range sr.TriggerBehaviours {
 		for _, tb := range value {
 			if len(tb.UnmetGuardConditions(ctx, args...)) == 0 {
@@ -235,7 +235,7 @@ func (sr *stateRepresentation[S, T]) PermittedTriggers(ctx context.Context, args
 	return
 }
 
-func (sr *stateRepresentation[S, T]) executeActivationActions(ctx context.Context) error {
+func (sr *stateRepresentation[_, _]) executeActivationActions(ctx context.Context) error {
 	for _, a := range sr.ActivateActions {
 		if err := a.Execute(ctx); err != nil {
 			return err
@@ -244,7 +244,7 @@ func (sr *stateRepresentation[S, T]) executeActivationActions(ctx context.Contex
 	return nil
 }
 
-func (sr *stateRepresentation[S, T]) executeDeactivationActions(ctx context.Context) error {
+func (sr *stateRepresentation[_, _]) executeDeactivationActions(ctx context.Context) error {
 	for _, a := range sr.DeactivateActions {
 		if err := a.Execute(ctx); err != nil {
 			return err

--- a/states_test.go
+++ b/states_test.go
@@ -8,64 +8,64 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func createSuperSubstatePair() (*stateRepresentation, *stateRepresentation) {
-	super := newstateRepresentation(stateA)
-	sub := newstateRepresentation(stateB)
+func createSuperSubstatePair() (*stateRepresentation[string, string], *stateRepresentation[string, string]) {
+	super := newstateRepresentation[string, string](stateA)
+	sub := newstateRepresentation[string, string](stateB)
 	super.Substates = append(super.Substates, sub)
 	sub.Superstate = super
 	return super, sub
 }
 
 func Test_stateRepresentation_Includes_SameState(t *testing.T) {
-	sr := newstateRepresentation(stateB)
+	sr := newstateRepresentation[string, string](stateB)
 	assert.True(t, sr.IncludeState(stateB))
 }
 
 func Test_stateRepresentation_Includes_Substate(t *testing.T) {
-	sr := newstateRepresentation(stateB)
-	sr.Substates = append(sr.Substates, newstateRepresentation(stateC))
+	sr := newstateRepresentation[string, string](stateB)
+	sr.Substates = append(sr.Substates, newstateRepresentation[string, string](stateC))
 	assert.True(t, sr.IncludeState(stateC))
 }
 
 func Test_stateRepresentation_Includes_UnrelatedState(t *testing.T) {
-	sr := newstateRepresentation(stateB)
+	sr := newstateRepresentation[string, string](stateB)
 	assert.False(t, sr.IncludeState(stateC))
 }
 
 func Test_stateRepresentation_Includes_Superstate(t *testing.T) {
-	sr := newstateRepresentation(stateB)
-	sr.Superstate = newstateRepresentation(stateC)
+	sr := newstateRepresentation[string, string](stateB)
+	sr.Superstate = newstateRepresentation[string, string](stateC)
 	assert.False(t, sr.IncludeState(stateC))
 }
 
 func Test_stateRepresentation_IsIncludedInState_SameState(t *testing.T) {
-	sr := newstateRepresentation(stateB)
+	sr := newstateRepresentation[string, string](stateB)
 	assert.True(t, sr.IsIncludedInState(stateB))
 }
 
 func Test_stateRepresentation_IsIncludedInState_Substate(t *testing.T) {
-	sr := newstateRepresentation(stateB)
-	sr.Substates = append(sr.Substates, newstateRepresentation(stateC))
+	sr := newstateRepresentation[string, string](stateB)
+	sr.Substates = append(sr.Substates, newstateRepresentation[string, string](stateC))
 	assert.False(t, sr.IsIncludedInState(stateC))
 }
 
 func Test_stateRepresentation_IsIncludedInState_UnrelatedState(t *testing.T) {
-	sr := newstateRepresentation(stateB)
+	sr := newstateRepresentation[string, string](stateB)
 	assert.False(t, sr.IsIncludedInState(stateC))
 }
 
 func Test_stateRepresentation_IsIncludedInState_Superstate(t *testing.T) {
-	sr := newstateRepresentation(stateB)
+	sr := newstateRepresentation[string, string](stateB)
 	assert.False(t, sr.IsIncludedInState(stateC))
 }
 
 func Test_stateRepresentation_CanHandle_TransitionExists_TriggerCannotBeFired(t *testing.T) {
-	sr := newstateRepresentation(stateB)
+	sr := newstateRepresentation[string, string](stateB)
 	assert.False(t, sr.CanHandle(context.Background(), triggerX))
 }
 
 func Test_stateRepresentation_CanHandle_TransitionDoesNotExist_TriggerCanBeFired(t *testing.T) {
-	sr := newstateRepresentation(stateB)
+	sr := newstateRepresentation[string, string](stateB)
 	sr.AddTriggerBehaviour(&ignoredTriggerBehaviour{baseTriggerBehaviour: baseTriggerBehaviour{Trigger: triggerX}})
 	assert.True(t, sr.CanHandle(context.Background(), triggerX))
 }
@@ -77,7 +77,7 @@ func Test_stateRepresentation_CanHandle_TransitionExistsInSupersate_TriggerCanBe
 }
 
 func Test_stateRepresentation_CanHandle_TransitionUnmetGuardConditions_TriggerCannotBeFired(t *testing.T) {
-	sr := newstateRepresentation(stateB)
+	sr := newstateRepresentation[string, string](stateB)
 	sr.AddTriggerBehaviour(&transitioningTriggerBehaviour{baseTriggerBehaviour: baseTriggerBehaviour{
 		Trigger: triggerX,
 		Guard: newtransitionGuard(func(_ context.Context, _ ...interface{}) bool {
@@ -90,7 +90,7 @@ func Test_stateRepresentation_CanHandle_TransitionUnmetGuardConditions_TriggerCa
 }
 
 func Test_stateRepresentation_CanHandle_TransitionGuardConditionsMet_TriggerCanBeFired(t *testing.T) {
-	sr := newstateRepresentation(stateB)
+	sr := newstateRepresentation[string, string](stateB)
 	sr.AddTriggerBehaviour(&transitioningTriggerBehaviour{baseTriggerBehaviour: baseTriggerBehaviour{
 		Trigger: triggerX,
 		Guard: newtransitionGuard(func(_ context.Context, _ ...interface{}) bool {
@@ -140,7 +140,7 @@ func Test_stateRepresentation_FindHandler_TransitionExistSuperstateMetGuardCondi
 }
 
 func Test_stateRepresentation_Enter_EnteringActionsExecuted(t *testing.T) {
-	sr := newstateRepresentation(stateB)
+	sr := newstateRepresentation[string, string](stateB)
 	transition := Transition{Source: stateA, Destination: stateB, Trigger: triggerX}
 	var actualTransition Transition
 	sr.EntryActions = append(sr.EntryActions, actionBehaviour{
@@ -155,7 +155,7 @@ func Test_stateRepresentation_Enter_EnteringActionsExecuted(t *testing.T) {
 }
 
 func Test_stateRepresentation_Enter_EnteringActionsExecuted_Error(t *testing.T) {
-	sr := newstateRepresentation(stateB)
+	sr := newstateRepresentation[string, string](stateB)
 	transition := Transition{Source: stateA, Destination: stateB, Trigger: triggerX}
 	var actualTransition Transition
 	sr.EntryActions = append(sr.EntryActions, actionBehaviour{
@@ -169,7 +169,7 @@ func Test_stateRepresentation_Enter_EnteringActionsExecuted_Error(t *testing.T) 
 }
 
 func Test_stateRepresentation_Enter_LeavingActionsNotExecuted(t *testing.T) {
-	sr := newstateRepresentation(stateA)
+	sr := newstateRepresentation[string, string](stateA)
 	transition := Transition{Source: stateA, Destination: stateB, Trigger: triggerX}
 	var actualTransition Transition
 	sr.ExitActions = append(sr.ExitActions, actionBehaviour{
@@ -226,7 +226,7 @@ func Test_stateRepresentation_Enter_Substate_SuperEntryActionsExecuted(t *testin
 
 func Test_stateRepresentation_Enter_ActionsExecuteInOrder(t *testing.T) {
 	var actual []int
-	sr := newstateRepresentation(stateB)
+	sr := newstateRepresentation[string, string](stateB)
 	sr.EntryActions = append(sr.EntryActions, actionBehaviour{
 		Action: func(_ context.Context, _ ...interface{}) error {
 			actual = append(actual, 0)
@@ -269,7 +269,7 @@ func Test_stateRepresentation_Enter_Substate_SuperstateEntryActionsExecuteBefore
 }
 
 func Test_stateRepresentation_Exit_EnteringActionsNotExecuted(t *testing.T) {
-	sr := newstateRepresentation(stateB)
+	sr := newstateRepresentation[string, string](stateB)
 	transition := Transition{Source: stateA, Destination: stateB, Trigger: triggerX}
 	var actualTransition Transition
 	sr.EntryActions = append(sr.EntryActions, actionBehaviour{
@@ -283,7 +283,7 @@ func Test_stateRepresentation_Exit_EnteringActionsNotExecuted(t *testing.T) {
 }
 
 func Test_stateRepresentation_Exit_LeavingActionsExecuted(t *testing.T) {
-	sr := newstateRepresentation(stateA)
+	sr := newstateRepresentation[string, string](stateA)
 	transition := Transition{Source: stateA, Destination: stateB, Trigger: triggerX}
 	var actualTransition Transition
 	sr.ExitActions = append(sr.ExitActions, actionBehaviour{
@@ -298,7 +298,7 @@ func Test_stateRepresentation_Exit_LeavingActionsExecuted(t *testing.T) {
 }
 
 func Test_stateRepresentation_Exit_LeavingActionsExecuted_Error(t *testing.T) {
-	sr := newstateRepresentation(stateA)
+	sr := newstateRepresentation[string, string](stateA)
 	transition := Transition{Source: stateA, Destination: stateB, Trigger: triggerX}
 	var actualTransition Transition
 	sr.ExitActions = append(sr.ExitActions, actionBehaviour{
@@ -327,9 +327,9 @@ func Test_stateRepresentation_Exit_FromSubToSuperstate_SubstateExitActionsExecut
 
 func Test_stateRepresentation_Exit_FromSubToOther_SuperstateExitActionsExecuted(t *testing.T) {
 	super, sub := createSuperSubstatePair()
-	supersuper := newstateRepresentation(stateC)
+	supersuper := newstateRepresentation[string, string](stateC)
 	super.Superstate = supersuper
-	supersuper.Superstate = newstateRepresentation(stateD)
+	supersuper.Superstate = newstateRepresentation[string, string](stateD)
 	executed := false
 	super.ExitActions = append(super.ExitActions, actionBehaviour{
 		Action: func(_ context.Context, _ ...interface{}) error {
@@ -372,7 +372,7 @@ func Test_stateRepresentation_Exit_Substate_SuperExitActionsExecuted(t *testing.
 
 func Test_stateRepresentation_Exit_ActionsExecuteInOrder(t *testing.T) {
 	var actual []int
-	sr := newstateRepresentation(stateB)
+	sr := newstateRepresentation[string, string](stateB)
 	sr.ExitActions = append(sr.ExitActions, actionBehaviour{
 		Action: func(_ context.Context, _ ...interface{}) error {
 			actual = append(actual, 0)

--- a/states_test.go
+++ b/states_test.go
@@ -66,19 +66,19 @@ func Test_stateRepresentation_CanHandle_TransitionExists_TriggerCannotBeFired(t 
 
 func Test_stateRepresentation_CanHandle_TransitionDoesNotExist_TriggerCanBeFired(t *testing.T) {
 	sr := newstateRepresentation[string, string](stateB)
-	sr.AddTriggerBehaviour(&ignoredTriggerBehaviour{baseTriggerBehaviour: baseTriggerBehaviour{Trigger: triggerX}})
+	sr.AddTriggerBehaviour(&ignoredTriggerBehaviour[string]{baseTriggerBehaviour: baseTriggerBehaviour[string]{Trigger: triggerX}})
 	assert.True(t, sr.CanHandle(context.Background(), triggerX))
 }
 
 func Test_stateRepresentation_CanHandle_TransitionExistsInSupersate_TriggerCanBeFired(t *testing.T) {
 	super, sub := createSuperSubstatePair()
-	super.AddTriggerBehaviour(&ignoredTriggerBehaviour{baseTriggerBehaviour: baseTriggerBehaviour{Trigger: triggerX}})
+	super.AddTriggerBehaviour(&ignoredTriggerBehaviour[string]{baseTriggerBehaviour: baseTriggerBehaviour[string]{Trigger: triggerX}})
 	assert.True(t, sub.CanHandle(context.Background(), triggerX))
 }
 
 func Test_stateRepresentation_CanHandle_TransitionUnmetGuardConditions_TriggerCannotBeFired(t *testing.T) {
 	sr := newstateRepresentation[string, string](stateB)
-	sr.AddTriggerBehaviour(&transitioningTriggerBehaviour{baseTriggerBehaviour: baseTriggerBehaviour{
+	sr.AddTriggerBehaviour(&transitioningTriggerBehaviour[string, string]{baseTriggerBehaviour: baseTriggerBehaviour[string]{
 		Trigger: triggerX,
 		Guard: newtransitionGuard(func(_ context.Context, _ ...interface{}) bool {
 			return true
@@ -91,7 +91,7 @@ func Test_stateRepresentation_CanHandle_TransitionUnmetGuardConditions_TriggerCa
 
 func Test_stateRepresentation_CanHandle_TransitionGuardConditionsMet_TriggerCanBeFired(t *testing.T) {
 	sr := newstateRepresentation[string, string](stateB)
-	sr.AddTriggerBehaviour(&transitioningTriggerBehaviour{baseTriggerBehaviour: baseTriggerBehaviour{
+	sr.AddTriggerBehaviour(&transitioningTriggerBehaviour[string, string]{baseTriggerBehaviour: baseTriggerBehaviour[string]{
 		Trigger: triggerX,
 		Guard: newtransitionGuard(func(_ context.Context, _ ...interface{}) bool {
 			return true
@@ -104,7 +104,7 @@ func Test_stateRepresentation_CanHandle_TransitionGuardConditionsMet_TriggerCanB
 
 func Test_stateRepresentation_FindHandler_TransitionExistAndSuperstateUnmetGuardConditions_FireNotPossible(t *testing.T) {
 	super, sub := createSuperSubstatePair()
-	super.AddTriggerBehaviour(&transitioningTriggerBehaviour{baseTriggerBehaviour: baseTriggerBehaviour{
+	super.AddTriggerBehaviour(&transitioningTriggerBehaviour[string, string]{baseTriggerBehaviour: baseTriggerBehaviour[string]{
 		Trigger: triggerX,
 		Guard: newtransitionGuard(func(_ context.Context, _ ...interface{}) bool {
 			return true
@@ -122,7 +122,7 @@ func Test_stateRepresentation_FindHandler_TransitionExistAndSuperstateUnmetGuard
 
 func Test_stateRepresentation_FindHandler_TransitionExistSuperstateMetGuardConditions_CanBeFired(t *testing.T) {
 	super, sub := createSuperSubstatePair()
-	super.AddTriggerBehaviour(&transitioningTriggerBehaviour{baseTriggerBehaviour: baseTriggerBehaviour{
+	super.AddTriggerBehaviour(&transitioningTriggerBehaviour[string, string]{baseTriggerBehaviour: baseTriggerBehaviour[string]{
 		Trigger: triggerX,
 		Guard: newtransitionGuard(func(_ context.Context, _ ...interface{}) bool {
 			return true
@@ -141,9 +141,9 @@ func Test_stateRepresentation_FindHandler_TransitionExistSuperstateMetGuardCondi
 
 func Test_stateRepresentation_Enter_EnteringActionsExecuted(t *testing.T) {
 	sr := newstateRepresentation[string, string](stateB)
-	transition := Transition{Source: stateA, Destination: stateB, Trigger: triggerX}
-	var actualTransition Transition
-	sr.EntryActions = append(sr.EntryActions, actionBehaviour{
+	transition := Transition[string, string]{Source: stateA, Destination: stateB, Trigger: triggerX}
+	var actualTransition Transition[string, string]
+	sr.EntryActions = append(sr.EntryActions, actionBehaviour[string, string]{
 		Action: func(_ context.Context, _ ...interface{}) error {
 			actualTransition = transition
 			return nil
@@ -156,9 +156,9 @@ func Test_stateRepresentation_Enter_EnteringActionsExecuted(t *testing.T) {
 
 func Test_stateRepresentation_Enter_EnteringActionsExecuted_Error(t *testing.T) {
 	sr := newstateRepresentation[string, string](stateB)
-	transition := Transition{Source: stateA, Destination: stateB, Trigger: triggerX}
-	var actualTransition Transition
-	sr.EntryActions = append(sr.EntryActions, actionBehaviour{
+	transition := Transition[string, string]{Source: stateA, Destination: stateB, Trigger: triggerX}
+	var actualTransition Transition[string, string]
+	sr.EntryActions = append(sr.EntryActions, actionBehaviour[string, string]{
 		Action: func(_ context.Context, _ ...interface{}) error {
 			return errors.New("")
 		},
@@ -170,9 +170,9 @@ func Test_stateRepresentation_Enter_EnteringActionsExecuted_Error(t *testing.T) 
 
 func Test_stateRepresentation_Enter_LeavingActionsNotExecuted(t *testing.T) {
 	sr := newstateRepresentation[string, string](stateA)
-	transition := Transition{Source: stateA, Destination: stateB, Trigger: triggerX}
-	var actualTransition Transition
-	sr.ExitActions = append(sr.ExitActions, actionBehaviour{
+	transition := Transition[string, string]{Source: stateA, Destination: stateB, Trigger: triggerX}
+	var actualTransition Transition[string, string]
+	sr.ExitActions = append(sr.ExitActions, actionBehaviour[string, string]{
 		Action: func(_ context.Context, _ ...interface{}) error {
 			actualTransition = transition
 			return nil
@@ -185,13 +185,13 @@ func Test_stateRepresentation_Enter_LeavingActionsNotExecuted(t *testing.T) {
 func Test_stateRepresentation_Enter_FromSubToSuperstate_SubstateEntryActionsExecuted(t *testing.T) {
 	super, sub := createSuperSubstatePair()
 	executed := false
-	sub.EntryActions = append(sub.EntryActions, actionBehaviour{
+	sub.EntryActions = append(sub.EntryActions, actionBehaviour[string, string]{
 		Action: func(_ context.Context, _ ...interface{}) error {
 			executed = true
 			return nil
 		},
 	})
-	transition := Transition{Source: super.State, Destination: sub.State, Trigger: triggerX}
+	transition := Transition[string, string]{Source: super.State, Destination: sub.State, Trigger: triggerX}
 	sub.Enter(context.Background(), transition)
 	assert.True(t, executed)
 }
@@ -199,13 +199,13 @@ func Test_stateRepresentation_Enter_FromSubToSuperstate_SubstateEntryActionsExec
 func Test_stateRepresentation_Enter_SuperFromSubstate_SuperEntryActionsNotExecuted(t *testing.T) {
 	super, sub := createSuperSubstatePair()
 	executed := false
-	super.EntryActions = append(super.EntryActions, actionBehaviour{
+	super.EntryActions = append(super.EntryActions, actionBehaviour[string, string]{
 		Action: func(_ context.Context, _ ...interface{}) error {
 			executed = true
 			return nil
 		},
 	})
-	transition := Transition{Source: super.State, Destination: sub.State, Trigger: triggerX}
+	transition := Transition[string, string]{Source: super.State, Destination: sub.State, Trigger: triggerX}
 	sub.Enter(context.Background(), transition)
 	assert.False(t, executed)
 }
@@ -213,13 +213,13 @@ func Test_stateRepresentation_Enter_SuperFromSubstate_SuperEntryActionsNotExecut
 func Test_stateRepresentation_Enter_Substate_SuperEntryActionsExecuted(t *testing.T) {
 	super, sub := createSuperSubstatePair()
 	executed := false
-	super.EntryActions = append(super.EntryActions, actionBehaviour{
+	super.EntryActions = append(super.EntryActions, actionBehaviour[string, string]{
 		Action: func(_ context.Context, _ ...interface{}) error {
 			executed = true
 			return nil
 		},
 	})
-	transition := Transition{Source: stateC, Destination: sub.State, Trigger: triggerX}
+	transition := Transition[string, string]{Source: stateC, Destination: sub.State, Trigger: triggerX}
 	sub.Enter(context.Background(), transition)
 	assert.True(t, executed)
 }
@@ -227,19 +227,19 @@ func Test_stateRepresentation_Enter_Substate_SuperEntryActionsExecuted(t *testin
 func Test_stateRepresentation_Enter_ActionsExecuteInOrder(t *testing.T) {
 	var actual []int
 	sr := newstateRepresentation[string, string](stateB)
-	sr.EntryActions = append(sr.EntryActions, actionBehaviour{
+	sr.EntryActions = append(sr.EntryActions, actionBehaviour[string, string]{
 		Action: func(_ context.Context, _ ...interface{}) error {
 			actual = append(actual, 0)
 			return nil
 		},
 	})
-	sr.EntryActions = append(sr.EntryActions, actionBehaviour{
+	sr.EntryActions = append(sr.EntryActions, actionBehaviour[string, string]{
 		Action: func(_ context.Context, _ ...interface{}) error {
 			actual = append(actual, 1)
 			return nil
 		},
 	})
-	transition := Transition{Source: stateA, Destination: stateB, Trigger: triggerX}
+	transition := Transition[string, string]{Source: stateA, Destination: stateB, Trigger: triggerX}
 	sr.Enter(context.Background(), transition)
 	assert.Equal(t, 2, len(actual))
 	assert.Equal(t, 0, actual[0])
@@ -249,30 +249,30 @@ func Test_stateRepresentation_Enter_ActionsExecuteInOrder(t *testing.T) {
 func Test_stateRepresentation_Enter_Substate_SuperstateEntryActionsExecuteBeforeSubstate(t *testing.T) {
 	super, sub := createSuperSubstatePair()
 	var order, subOrder, superOrder int
-	super.EntryActions = append(super.EntryActions, actionBehaviour{
+	super.EntryActions = append(super.EntryActions, actionBehaviour[string, string]{
 		Action: func(_ context.Context, _ ...interface{}) error {
 			order += 1
 			superOrder = order
 			return nil
 		},
 	})
-	sub.EntryActions = append(sub.EntryActions, actionBehaviour{
+	sub.EntryActions = append(sub.EntryActions, actionBehaviour[string, string]{
 		Action: func(_ context.Context, _ ...interface{}) error {
 			order += 1
 			subOrder = order
 			return nil
 		},
 	})
-	transition := Transition{Source: stateC, Destination: sub.State, Trigger: triggerX}
+	transition := Transition[string, string]{Source: stateC, Destination: sub.State, Trigger: triggerX}
 	sub.Enter(context.Background(), transition)
 	assert.True(t, superOrder < subOrder)
 }
 
 func Test_stateRepresentation_Exit_EnteringActionsNotExecuted(t *testing.T) {
 	sr := newstateRepresentation[string, string](stateB)
-	transition := Transition{Source: stateA, Destination: stateB, Trigger: triggerX}
-	var actualTransition Transition
-	sr.EntryActions = append(sr.EntryActions, actionBehaviour{
+	transition := Transition[string, string]{Source: stateA, Destination: stateB, Trigger: triggerX}
+	var actualTransition Transition[string, string]
+	sr.EntryActions = append(sr.EntryActions, actionBehaviour[string, string]{
 		Action: func(_ context.Context, _ ...interface{}) error {
 			actualTransition = transition
 			return nil
@@ -284,9 +284,9 @@ func Test_stateRepresentation_Exit_EnteringActionsNotExecuted(t *testing.T) {
 
 func Test_stateRepresentation_Exit_LeavingActionsExecuted(t *testing.T) {
 	sr := newstateRepresentation[string, string](stateA)
-	transition := Transition{Source: stateA, Destination: stateB, Trigger: triggerX}
-	var actualTransition Transition
-	sr.ExitActions = append(sr.ExitActions, actionBehaviour{
+	transition := Transition[string, string]{Source: stateA, Destination: stateB, Trigger: triggerX}
+	var actualTransition Transition[string, string]
+	sr.ExitActions = append(sr.ExitActions, actionBehaviour[string, string]{
 		Action: func(_ context.Context, _ ...interface{}) error {
 			actualTransition = transition
 			return nil
@@ -299,9 +299,9 @@ func Test_stateRepresentation_Exit_LeavingActionsExecuted(t *testing.T) {
 
 func Test_stateRepresentation_Exit_LeavingActionsExecuted_Error(t *testing.T) {
 	sr := newstateRepresentation[string, string](stateA)
-	transition := Transition{Source: stateA, Destination: stateB, Trigger: triggerX}
-	var actualTransition Transition
-	sr.ExitActions = append(sr.ExitActions, actionBehaviour{
+	transition := Transition[string, string]{Source: stateA, Destination: stateB, Trigger: triggerX}
+	var actualTransition Transition[string, string]
+	sr.ExitActions = append(sr.ExitActions, actionBehaviour[string, string]{
 		Action: func(_ context.Context, _ ...interface{}) error {
 			return errors.New("")
 		},
@@ -314,13 +314,13 @@ func Test_stateRepresentation_Exit_LeavingActionsExecuted_Error(t *testing.T) {
 func Test_stateRepresentation_Exit_FromSubToSuperstate_SubstateExitActionsExecuted(t *testing.T) {
 	super, sub := createSuperSubstatePair()
 	executed := false
-	sub.ExitActions = append(sub.ExitActions, actionBehaviour{
+	sub.ExitActions = append(sub.ExitActions, actionBehaviour[string, string]{
 		Action: func(_ context.Context, _ ...interface{}) error {
 			executed = true
 			return nil
 		},
 	})
-	transition := Transition{Source: sub.State, Destination: super.State, Trigger: triggerX}
+	transition := Transition[string, string]{Source: sub.State, Destination: super.State, Trigger: triggerX}
 	sub.Exit(context.Background(), transition)
 	assert.True(t, executed)
 }
@@ -331,13 +331,13 @@ func Test_stateRepresentation_Exit_FromSubToOther_SuperstateExitActionsExecuted(
 	super.Superstate = supersuper
 	supersuper.Superstate = newstateRepresentation[string, string](stateD)
 	executed := false
-	super.ExitActions = append(super.ExitActions, actionBehaviour{
+	super.ExitActions = append(super.ExitActions, actionBehaviour[string, string]{
 		Action: func(_ context.Context, _ ...interface{}) error {
 			executed = true
 			return nil
 		},
 	})
-	transition := Transition{Source: sub.State, Destination: stateD, Trigger: triggerX}
+	transition := Transition[string, string]{Source: sub.State, Destination: stateD, Trigger: triggerX}
 	sub.Exit(context.Background(), transition)
 	assert.True(t, executed)
 }
@@ -345,13 +345,13 @@ func Test_stateRepresentation_Exit_FromSubToOther_SuperstateExitActionsExecuted(
 func Test_stateRepresentation_Exit_FromSuperToSubstate_SuperExitActionsNotExecuted(t *testing.T) {
 	super, sub := createSuperSubstatePair()
 	executed := false
-	super.ExitActions = append(super.ExitActions, actionBehaviour{
+	super.ExitActions = append(super.ExitActions, actionBehaviour[string, string]{
 		Action: func(_ context.Context, _ ...interface{}) error {
 			executed = true
 			return nil
 		},
 	})
-	transition := Transition{Source: super.State, Destination: sub.State, Trigger: triggerX}
+	transition := Transition[string, string]{Source: super.State, Destination: sub.State, Trigger: triggerX}
 	sub.Exit(context.Background(), transition)
 	assert.False(t, executed)
 }
@@ -359,13 +359,13 @@ func Test_stateRepresentation_Exit_FromSuperToSubstate_SuperExitActionsNotExecut
 func Test_stateRepresentation_Exit_Substate_SuperExitActionsExecuted(t *testing.T) {
 	super, sub := createSuperSubstatePair()
 	executed := false
-	super.ExitActions = append(super.ExitActions, actionBehaviour{
+	super.ExitActions = append(super.ExitActions, actionBehaviour[string, string]{
 		Action: func(_ context.Context, _ ...interface{}) error {
 			executed = true
 			return nil
 		},
 	})
-	transition := Transition{Source: sub.State, Destination: stateC, Trigger: triggerX}
+	transition := Transition[string, string]{Source: sub.State, Destination: stateC, Trigger: triggerX}
 	sub.Exit(context.Background(), transition)
 	assert.True(t, executed)
 }
@@ -373,19 +373,19 @@ func Test_stateRepresentation_Exit_Substate_SuperExitActionsExecuted(t *testing.
 func Test_stateRepresentation_Exit_ActionsExecuteInOrder(t *testing.T) {
 	var actual []int
 	sr := newstateRepresentation[string, string](stateB)
-	sr.ExitActions = append(sr.ExitActions, actionBehaviour{
+	sr.ExitActions = append(sr.ExitActions, actionBehaviour[string, string]{
 		Action: func(_ context.Context, _ ...interface{}) error {
 			actual = append(actual, 0)
 			return nil
 		},
 	})
-	sr.ExitActions = append(sr.ExitActions, actionBehaviour{
+	sr.ExitActions = append(sr.ExitActions, actionBehaviour[string, string]{
 		Action: func(_ context.Context, _ ...interface{}) error {
 			actual = append(actual, 1)
 			return nil
 		},
 	})
-	transition := Transition{Source: stateB, Destination: stateC, Trigger: triggerX}
+	transition := Transition[string, string]{Source: stateB, Destination: stateC, Trigger: triggerX}
 	sr.Exit(context.Background(), transition)
 	assert.Equal(t, 2, len(actual))
 	assert.Equal(t, 0, actual[0])
@@ -395,21 +395,21 @@ func Test_stateRepresentation_Exit_ActionsExecuteInOrder(t *testing.T) {
 func Test_stateRepresentation_Exit_Substate_SubstateEntryActionsExecuteBeforeSuperstate(t *testing.T) {
 	super, sub := createSuperSubstatePair()
 	var order, subOrder, superOrder int
-	super.ExitActions = append(super.ExitActions, actionBehaviour{
+	super.ExitActions = append(super.ExitActions, actionBehaviour[string, string]{
 		Action: func(_ context.Context, _ ...interface{}) error {
 			order += 1
 			superOrder = order
 			return nil
 		},
 	})
-	sub.ExitActions = append(sub.ExitActions, actionBehaviour{
+	sub.ExitActions = append(sub.ExitActions, actionBehaviour[string, string]{
 		Action: func(_ context.Context, _ ...interface{}) error {
 			order += 1
 			subOrder = order
 			return nil
 		},
 	})
-	transition := Transition{Source: sub.State, Destination: stateC, Trigger: triggerX}
+	transition := Transition[string, string]{Source: sub.State, Destination: stateC, Trigger: triggerX}
 	sub.Exit(context.Background(), transition)
 	assert.True(t, subOrder < superOrder)
 }

--- a/triggers.go
+++ b/triggers.go
@@ -86,11 +86,11 @@ func (t *baseTriggerBehaviour[T]) GetTrigger() T {
 	return t.Trigger
 }
 
-func (t *baseTriggerBehaviour[T]) GuardConditionMet(ctx context.Context, args ...interface{}) bool {
+func (t *baseTriggerBehaviour[_]) GuardConditionMet(ctx context.Context, args ...interface{}) bool {
 	return t.Guard.GuardConditionMet(ctx, args...)
 }
 
-func (t *baseTriggerBehaviour[T]) UnmetGuardConditions(ctx context.Context, args ...interface{}) []string {
+func (t *baseTriggerBehaviour[_]) UnmetGuardConditions(ctx context.Context, args ...interface{}) []string {
 	return t.Guard.UnmetGuardConditions(ctx, args...)
 }
 
@@ -113,7 +113,7 @@ type dynamicTriggerBehaviour[S State, T Trigger] struct {
 	Destination func(context.Context, ...interface{}) (S, error)
 }
 
-func (t *dynamicTriggerBehaviour[S, T]) ResultsInTransitionFrom(ctx context.Context, _ S, args ...interface{}) (st S, ok bool) {
+func (t *dynamicTriggerBehaviour[S, _]) ResultsInTransitionFrom(ctx context.Context, _ S, args ...interface{}) (st S, ok bool) {
 	var err error
 	st, err = t.Destination(ctx, args...)
 	if err == nil {
@@ -143,7 +143,7 @@ type triggerWithParameters[T Trigger] struct {
 	ArgumentTypes []reflect.Type
 }
 
-func (t triggerWithParameters[T]) validateParameters(args ...interface{}) {
+func (t triggerWithParameters[_]) validateParameters(args ...interface{}) {
 	if len(args) != len(t.ArgumentTypes) {
 		panic(fmt.Sprintf("stateless: Too many parameters have been supplied. Expecting '%d' but got '%d'.", len(t.ArgumentTypes), len(args)))
 	}

--- a/triggers.go
+++ b/triggers.go
@@ -71,49 +71,49 @@ func (t transitionGuard) UnmetGuardConditions(ctx context.Context, args ...inter
 	return unmet
 }
 
-type triggerBehaviour interface {
+type triggerBehaviour[T Trigger] interface {
 	GuardConditionMet(context.Context, ...interface{}) bool
 	UnmetGuardConditions(context.Context, ...interface{}) []string
-	GetTrigger() Trigger
+	GetTrigger() T
 }
 
-type baseTriggerBehaviour struct {
+type baseTriggerBehaviour[T Trigger] struct {
 	Guard   transitionGuard
-	Trigger Trigger
+	Trigger T
 }
 
-func (t *baseTriggerBehaviour) GetTrigger() Trigger {
+func (t *baseTriggerBehaviour[T]) GetTrigger() T {
 	return t.Trigger
 }
 
-func (t *baseTriggerBehaviour) GuardConditionMet(ctx context.Context, args ...interface{}) bool {
+func (t *baseTriggerBehaviour[T]) GuardConditionMet(ctx context.Context, args ...interface{}) bool {
 	return t.Guard.GuardConditionMet(ctx, args...)
 }
 
-func (t *baseTriggerBehaviour) UnmetGuardConditions(ctx context.Context, args ...interface{}) []string {
+func (t *baseTriggerBehaviour[T]) UnmetGuardConditions(ctx context.Context, args ...interface{}) []string {
 	return t.Guard.UnmetGuardConditions(ctx, args...)
 }
 
-type ignoredTriggerBehaviour struct {
-	baseTriggerBehaviour
+type ignoredTriggerBehaviour[T Trigger] struct {
+	baseTriggerBehaviour[T]
 }
 
-type reentryTriggerBehaviour struct {
-	baseTriggerBehaviour
-	Destination State
+type reentryTriggerBehaviour[S State, T Trigger] struct {
+	baseTriggerBehaviour[T]
+	Destination S
 }
 
-type transitioningTriggerBehaviour struct {
-	baseTriggerBehaviour
-	Destination State
+type transitioningTriggerBehaviour[S State, T Trigger] struct {
+	baseTriggerBehaviour[T]
+	Destination S
 }
 
-type dynamicTriggerBehaviour struct {
-	baseTriggerBehaviour
-	Destination func(context.Context, ...interface{}) (State, error)
+type dynamicTriggerBehaviour[S State, T Trigger] struct {
+	baseTriggerBehaviour[T]
+	Destination func(context.Context, ...interface{}) (S, error)
 }
 
-func (t *dynamicTriggerBehaviour) ResultsInTransitionFrom(ctx context.Context, _ State, args ...interface{}) (st State, ok bool) {
+func (t *dynamicTriggerBehaviour[S, T]) ResultsInTransitionFrom(ctx context.Context, _ S, args ...interface{}) (st S, ok bool) {
 	var err error
 	st, err = t.Destination(ctx, args...)
 	if err == nil {
@@ -122,28 +122,28 @@ func (t *dynamicTriggerBehaviour) ResultsInTransitionFrom(ctx context.Context, _
 	return
 }
 
-type internalTriggerBehaviour struct {
-	baseTriggerBehaviour
+type internalTriggerBehaviour[S State, T Trigger] struct {
+	baseTriggerBehaviour[T]
 	Action ActionFunc
 }
 
-func (t *internalTriggerBehaviour) Execute(ctx context.Context, transition Transition, args ...interface{}) error {
+func (t *internalTriggerBehaviour[S, T]) Execute(ctx context.Context, transition Transition[S, T], args ...interface{}) error {
 	ctx = withTransition(ctx, transition)
 	return t.Action(ctx, args...)
 }
 
-type triggerBehaviourResult struct {
-	Handler              triggerBehaviour
+type triggerBehaviourResult[T Trigger] struct {
+	Handler              triggerBehaviour[T]
 	UnmetGuardConditions []string
 }
 
 // triggerWithParameters associates configured parameters with an underlying trigger value.
-type triggerWithParameters struct {
-	Trigger       Trigger
+type triggerWithParameters[T Trigger] struct {
+	Trigger       T
 	ArgumentTypes []reflect.Type
 }
 
-func (t triggerWithParameters) validateParameters(args ...interface{}) {
+func (t triggerWithParameters[T]) validateParameters(args ...interface{}) {
 	if len(args) != len(t.ArgumentTypes) {
 		panic(fmt.Sprintf("stateless: Too many parameters have been supplied. Expecting '%d' but got '%d'.", len(t.ArgumentTypes), len(args)))
 	}


### PR DESCRIPTION
This PR is just to view which are the changes required to adopt Go 1.18 type parameters. I'm still not sure if it is worth making State and Trigger generic compared to the overhead of having type parameters polluting almost all internal functions.