### PR TITLE
Don't panic when the context passed GetTransition does not contain a transition key

### DIFF
--- a/config.go
+++ b/config.go
@@ -14,7 +14,8 @@ func withTransition(ctx context.Context, transition Transition) context.Context 
 // GetTransition returns the transition from the context.
 // If there is no transition the returned value is empty.
 func GetTransition(ctx context.Context) Transition {
-	return ctx.Value(transitionKey{}).(Transition)
+	tr, _ := ctx.Value(transitionKey{}).(Transition)
+	return tr
 }
 
 // ActionFunc describes a generic action function.

--- a/statemachine_test.go
+++ b/statemachine_test.go
@@ -1369,3 +1369,8 @@ func TestStateMachine_Firing_Concurrent(t *testing.T) {
 	wg.Wait()
 	assert.False(t, sm.Firing())
 }
+
+func TestGetTransition_ContextEmpty(t *testing.T) {
+	// It should not panic
+	GetTransition(context.Background())
+}


### PR DESCRIPTION
Fixes #36 