### PR TITLE
Relax SetTriggerParameters check to allow all Go allowed casts

### DIFF
--- a/statemachine_test.go
+++ b/statemachine_test.go
@@ -317,6 +317,14 @@ func TestStateMachine_SetTriggerParameters_TriggerParametersAreImmutableOnceSet(
 	assert.Panics(t, func() { sm.SetTriggerParameters(triggerX, reflect.TypeOf(""), reflect.TypeOf(0)) })
 }
 
+func TestStateMachine_SetTriggerParameters_Interfaces(t *testing.T) {
+	sm := NewStateMachine(stateB)
+	sm.SetTriggerParameters(triggerX, reflect.TypeOf((*error)(nil)).Elem())
+
+	sm.Configure(stateB).Permit(triggerX, stateA)
+	assert.NotPanics(t, func() { sm.Fire(triggerX, errors.New("failed")) })
+}
+
 func TestStateMachine_SetTriggerParameters_Invalid(t *testing.T) {
 	sm := NewStateMachine(stateB)
 

--- a/triggers.go
+++ b/triggers.go
@@ -148,8 +148,10 @@ func (t triggerWithParameters) validateParameters(args ...interface{}) {
 		panic(fmt.Sprintf("stateless: Too many parameters have been supplied. Expecting '%d' but got '%d'.", len(t.ArgumentTypes), len(args)))
 	}
 	for i := range t.ArgumentTypes {
-		if t.ArgumentTypes[i] != reflect.TypeOf(args[i]) {
-			panic(fmt.Sprintf("stateless: The argument in position '%d' is of type '%v' but must be of type '%v'.", i, reflect.TypeOf(args[i]), t.ArgumentTypes[i]))
+		tp := reflect.TypeOf(args[i])
+		want := t.ArgumentTypes[i]
+		if !tp.ConvertibleTo(want) {
+			panic(fmt.Sprintf("stateless: The argument in position '%d' is of type '%v' but must be convertible to '%v'.", i, tp, want))
 		}
 	}
 }


### PR DESCRIPTION
This PR updates `SetTriggerParameters` so it uses `reflect.ConvertibleTo` instead of plain type equality.