### PR TITLE
Fix unaligned panic on 32 bit arm

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x, 1.18.x]
+        go-version: [1.19.x, 1.20.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/qmuntal/stateless
 
-go 1.17
+go 1.19
 
 require github.com/stretchr/testify v1.8.1
 


### PR DESCRIPTION
Fixes #52

There was a partial fix for this issue in #32. This time I've used [atomic.Uint64](https://pkg.go.dev/sync/atomic#Uint64) which is guaranteed to be correctly aligned. The unfortunate side-efect is that it requires go1.19.