### PR TITLE
Rewrite interface{} to any

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,18 @@ phoneCall := stateless.NewStateMachine(stateOffHook)
 phoneCall.Configure(stateOffHook).Permit(triggerCallDialed, stateRinging)
 
 phoneCall.Configure(stateRinging).
-  OnEntryFrom(triggerCallDialed, func(_ context.Context, args ...interface{}) error {
+  OnEntryFrom(triggerCallDialed, func(_ context.Context, args ...any) error {
     onDialed(args[0].(string))
     return nil
   }).
   Permit(triggerCallConnected, stateConnected)
 
 phoneCall.Configure(stateConnected).
-  OnEntry(func(_ context.Context, _ ...interface{}) error {
+  OnEntry(func(_ context.Context, _ ...any) error {
     startCallTimer()
     return nil
   }).
-  OnExit(func(_ context.Context, _ ...interface{}) error {
+  OnExit(func(_ context.Context, _ ...any) error {
     stopCallTimer()
     return nil
   }).
@@ -126,10 +126,10 @@ The state machine will choose between multiple transitions based on guard clause
 
 ```go
 phoneCall.Configure(stateOffHook).
-  Permit(triggerCallDialled, stateRinging, func(_ context.Context, _ ...interface{}) bool {
+  Permit(triggerCallDialled, stateRinging, func(_ context.Context, _ ...any) bool {
     return IsValidNumber()
   }).
-  Permit(triggerCallDialled, stateBeeping, func(_ context.Context, _ ...interface{}) bool {
+  Permit(triggerCallDialled, stateBeeping, func(_ context.Context, _ ...any) bool {
     return !IsValidNumber()
   })
 ```
@@ -146,7 +146,7 @@ Strongly-typed parameters can be assigned to triggers:
 stateMachine.SetTriggerParameters(triggerCallDialed, reflect.TypeOf(""))
 
 stateMachine.Configure(stateRinging).
-  OnEntryFrom(triggerCallDialed, func(_ context.Context, args ...interface{}) error {
+  OnEntryFrom(triggerCallDialed, func(_ context.Context, args ...any) error {
     fmt.Println(args[0].(string))
     return nil
   })
@@ -174,7 +174,7 @@ Alternatively, a state can be marked reentrant so its entry and exit events will
 ```go
 stateMachine.Configure(stateAssigned).
   PermitReentry(triggerAssigned).
-  OnEntry(func(_ context.Context, _ ...interface{}) error {
+  OnEntry(func(_ context.Context, _ ...any) error {
     startCallTimer()
     return nil
   })

--- a/config.go
+++ b/config.go
@@ -20,13 +20,13 @@ func GetTransition(ctx context.Context) Transition {
 
 // ActionFunc describes a generic action function.
 // The context will always contain Transition information.
-type ActionFunc = func(ctx context.Context, args ...interface{}) error
+type ActionFunc = func(ctx context.Context, args ...any) error
 
 // GuardFunc defines a generic guard function.
-type GuardFunc = func(ctx context.Context, args ...interface{}) bool
+type GuardFunc = func(ctx context.Context, args ...any) bool
 
 // DestinationSelectorFunc defines a functions that is called to select a dynamic destination.
-type DestinationSelectorFunc = func(ctx context.Context, args ...interface{}) (State, error)
+type DestinationSelectorFunc = func(ctx context.Context, args ...any) (State, error)
 
 // StateConfiguration is the configuration for a single state value.
 type StateConfiguration struct {

--- a/example_test.go
+++ b/example_test.go
@@ -37,7 +37,7 @@ func Example() {
 		Permit(triggerCallDialed, stateRinging)
 
 	phoneCall.Configure(stateRinging).
-		OnEntryFrom(triggerCallDialed, func(_ context.Context, args ...interface{}) error {
+		OnEntryFrom(triggerCallDialed, func(_ context.Context, args ...any) error {
 			onDialed(args[0].(string))
 			return nil
 		}).
@@ -45,19 +45,19 @@ func Example() {
 
 	phoneCall.Configure(stateConnected).
 		OnEntry(startCallTimer).
-		OnExit(func(_ context.Context, _ ...interface{}) error {
+		OnExit(func(_ context.Context, _ ...any) error {
 			stopCallTimer()
 			return nil
 		}).
-		InternalTransition(triggerMuteMicrophone, func(_ context.Context, _ ...interface{}) error {
+		InternalTransition(triggerMuteMicrophone, func(_ context.Context, _ ...any) error {
 			onMute()
 			return nil
 		}).
-		InternalTransition(triggerUnmuteMicrophone, func(_ context.Context, _ ...interface{}) error {
+		InternalTransition(triggerUnmuteMicrophone, func(_ context.Context, _ ...any) error {
 			onUnmute()
 			return nil
 		}).
-		InternalTransition(triggerSetVolume, func(_ context.Context, args ...interface{}) error {
+		InternalTransition(triggerSetVolume, func(_ context.Context, args ...any) error {
 			onSetVolume(args[0].(int))
 			return nil
 		}).
@@ -111,7 +111,7 @@ func onDialed(callee string) {
 	fmt.Printf("[Phone Call] placed for : [%s]\n", callee)
 }
 
-func startCallTimer(_ context.Context, _ ...interface{}) error {
+func startCallTimer(_ context.Context, _ ...any) error {
 	fmt.Println("[Timer:] Call started at 11:00am")
 	return nil
 }

--- a/graph.go
+++ b/graph.go
@@ -180,7 +180,7 @@ func (g *graph) formatOneLine(fromNodeName, toNodeName, label string) string {
 	return sb.String()
 }
 
-func clusterStr(state interface{}, quote, init bool) string {
+func clusterStr(state any, quote, init bool) string {
 	s := fmt.Sprint(state)
 	if init {
 		s += "-init"
@@ -188,7 +188,7 @@ func clusterStr(state interface{}, quote, init bool) string {
 	return esc("cluster_"+s, quote)
 }
 
-func str(v interface{}, quote bool) string {
+func str(v any, quote bool) string {
 	return esc(fmt.Sprint(v), quote)
 }
 

--- a/graph_test.go
+++ b/graph_test.go
@@ -45,19 +45,19 @@ func withGuards() *stateless.StateMachine {
 	sm := stateless.NewStateMachine("B")
 	sm.SetTriggerParameters("X", reflect.TypeOf(0))
 	sm.Configure("A").
-		Permit("X", "D", func(_ context.Context, args ...interface{}) bool {
+		Permit("X", "D", func(_ context.Context, args ...any) bool {
 			return args[0].(int) == 3
 		})
 
 	sm.Configure("B").
 		SubstateOf("A").
-		Permit("X", "C", func(_ context.Context, args ...interface{}) bool {
+		Permit("X", "C", func(_ context.Context, args ...any) bool {
 			return args[0].(int) == 2
 		})
 	return sm
 }
 
-func œ(_ context.Context, args ...interface{}) bool {
+func œ(_ context.Context, args ...any) bool {
 	return args[0].(int) == 2
 }
 
@@ -88,23 +88,23 @@ func phoneCall() *stateless.StateMachine {
 		Permit(triggerCallDialed, stateRinging)
 
 	phoneCall.Configure(stateRinging).
-		OnEntryFrom(triggerCallDialed, func(_ context.Context, args ...interface{}) error {
+		OnEntryFrom(triggerCallDialed, func(_ context.Context, args ...any) error {
 			return nil
 		}).
 		Permit(triggerCallConnected, stateConnected)
 
 	phoneCall.Configure(stateConnected).
 		OnEntry(startCallTimer).
-		OnExit(func(_ context.Context, _ ...interface{}) error {
+		OnExit(func(_ context.Context, _ ...any) error {
 			return nil
 		}).
-		InternalTransition(triggerMuteMicrophone, func(_ context.Context, _ ...interface{}) error {
+		InternalTransition(triggerMuteMicrophone, func(_ context.Context, _ ...any) error {
 			return nil
 		}).
-		InternalTransition(triggerUnmuteMicrophone, func(_ context.Context, _ ...interface{}) error {
+		InternalTransition(triggerUnmuteMicrophone, func(_ context.Context, _ ...any) error {
 			return nil
 		}).
-		InternalTransition(triggerSetVolume, func(_ context.Context, args ...interface{}) error {
+		InternalTransition(triggerSetVolume, func(_ context.Context, args ...any) error {
 			return nil
 		}).
 		Permit(triggerLeftMessage, stateOffHook).

--- a/statemachine_test.go
+++ b/statemachine_test.go
@@ -170,7 +170,7 @@ func TestStateMachine_PermittedTriggers_PermittedTriggersAreDistinctValues(t *te
 
 func TestStateMachine_PermittedTriggers_AcceptedTriggersRespectGuards(t *testing.T) {
 	sm := NewStateMachine(stateB)
-	sm.Configure(stateB).Permit(triggerX, stateA, func(_ context.Context, _ ...interface{}) bool {
+	sm.Configure(stateB).Permit(triggerX, stateA, func(_ context.Context, _ ...any) bool {
 		return false
 	})
 
@@ -181,9 +181,9 @@ func TestStateMachine_PermittedTriggers_AcceptedTriggersRespectGuards(t *testing
 
 func TestStateMachine_PermittedTriggers_AcceptedTriggersRespectMultipleGuards(t *testing.T) {
 	sm := NewStateMachine(stateB)
-	sm.Configure(stateB).Permit(triggerX, stateA, func(_ context.Context, _ ...interface{}) bool {
+	sm.Configure(stateB).Permit(triggerX, stateA, func(_ context.Context, _ ...any) bool {
 		return true
-	}, func(_ context.Context, _ ...interface{}) bool {
+	}, func(_ context.Context, _ ...any) bool {
 		return false
 	})
 
@@ -195,10 +195,10 @@ func TestStateMachine_PermittedTriggers_AcceptedTriggersRespectMultipleGuards(t 
 func TestStateMachine_Fire_DiscriminatedByGuard_ChoosesPermitedTransition(t *testing.T) {
 	sm := NewStateMachine(stateB)
 	sm.Configure(stateB).
-		Permit(triggerX, stateA, func(_ context.Context, _ ...interface{}) bool {
+		Permit(triggerX, stateA, func(_ context.Context, _ ...any) bool {
 			return false
 		}).
-		Permit(triggerX, stateC, func(_ context.Context, _ ...interface{}) bool {
+		Permit(triggerX, stateC, func(_ context.Context, _ ...any) bool {
 			return true
 		})
 
@@ -223,7 +223,7 @@ func TestStateMachine_Fire_TriggerIsIgnored_ActionsNotExecuted(t *testing.T) {
 	fired := false
 	sm := NewStateMachine(stateB)
 	sm.Configure(stateB).
-		OnEntry(func(_ context.Context, _ ...interface{}) error {
+		OnEntry(func(_ context.Context, _ ...any) error {
 			fired = true
 			return nil
 		}).
@@ -238,7 +238,7 @@ func TestStateMachine_Fire_SelfTransitionPermited_ActionsFire(t *testing.T) {
 	fired := false
 	sm := NewStateMachine(stateB)
 	sm.Configure(stateB).
-		OnEntry(func(_ context.Context, _ ...interface{}) error {
+		OnEntry(func(_ context.Context, _ ...any) error {
 			fired = true
 			return nil
 		}).
@@ -264,7 +264,7 @@ func TestStateMachine_Fire_ErrorForInvalidTransition(t *testing.T) {
 
 func TestStateMachine_Fire_ErrorForInvalidTransitionMentionsGuardDescriptionIfPresent(t *testing.T) {
 	sm := NewStateMachine(stateA)
-	sm.Configure(stateA).Permit(triggerX, stateB, func(_ context.Context, _ ...interface{}) bool {
+	sm.Configure(stateA).Permit(triggerX, stateB, func(_ context.Context, _ ...any) bool {
 		return false
 	})
 	assert.Error(t, sm.Fire(triggerX))
@@ -279,7 +279,7 @@ func TestStateMachine_Fire_ParametersSuppliedToFireArePassedToEntryAction(t *tes
 		entryArg1 string
 		entryArg2 int
 	)
-	sm.Configure(stateC).OnEntryFrom(triggerX, func(_ context.Context, args ...interface{}) error {
+	sm.Configure(stateC).OnEntryFrom(triggerX, func(_ context.Context, args ...any) error {
 		entryArg1 = args[0].(string)
 		entryArg2 = args[1].(int)
 		return nil
@@ -373,13 +373,13 @@ func TestStateMachine_OnTransitioned_EventFiresBeforeTheOnEntryEvent(t *testing.
 	expectedOrdering := []string{"OnExit", "OnTransitioning", "OnEntry", "OnTransitioned"}
 	var actualOrdering []string
 
-	sm.Configure(stateB).Permit(triggerX, stateA).OnExit(func(_ context.Context, args ...interface{}) error {
+	sm.Configure(stateB).Permit(triggerX, stateA).OnExit(func(_ context.Context, args ...any) error {
 		actualOrdering = append(actualOrdering, "OnExit")
 		return nil
 	}).Machine()
 
 	var transition Transition
-	sm.Configure(stateA).OnEntry(func(ctx context.Context, args ...interface{}) error {
+	sm.Configure(stateA).OnEntry(func(ctx context.Context, args ...any) error {
 		actualOrdering = append(actualOrdering, "OnEntry")
 		transition = GetTransition(ctx)
 		return nil
@@ -430,7 +430,7 @@ func TestStateMachine_Fire_IgnoreVsPermitReentry(t *testing.T) {
 	sm := NewStateMachine(stateA)
 	var calls int
 	sm.Configure(stateA).
-		OnEntry(func(_ context.Context, _ ...interface{}) error {
+		OnEntry(func(_ context.Context, _ ...any) error {
 			calls += 1
 			return nil
 		}).
@@ -447,11 +447,11 @@ func TestStateMachine_Fire_IgnoreVsPermitReentryFrom(t *testing.T) {
 	sm := NewStateMachine(stateA)
 	var calls int
 	sm.Configure(stateA).
-		OnEntryFrom(triggerX, func(_ context.Context, _ ...interface{}) error {
+		OnEntryFrom(triggerX, func(_ context.Context, _ ...any) error {
 			calls += 1
 			return nil
 		}).
-		OnEntryFrom(triggerY, func(_ context.Context, _ ...interface{}) error {
+		OnEntryFrom(triggerY, func(_ context.Context, _ ...any) error {
 			calls += 1
 			return nil
 		}).
@@ -468,19 +468,19 @@ func TestStateMachine_Fire_IfSelfTransitionPermited_ActionsFire_InSubstate(t *te
 	sm := NewStateMachine(stateA)
 	var onEntryStateBfired, onExitStateBfired, onExitStateAfired bool
 	sm.Configure(stateB).
-		OnEntry(func(_ context.Context, _ ...interface{}) error {
+		OnEntry(func(_ context.Context, _ ...any) error {
 			onEntryStateBfired = true
 			return nil
 		}).
 		PermitReentry(triggerX).
-		OnExit(func(_ context.Context, _ ...interface{}) error {
+		OnExit(func(_ context.Context, _ ...any) error {
 			onExitStateBfired = true
 			return nil
 		})
 
 	sm.Configure(stateA).
 		SubstateOf(stateB).
-		OnExit(func(_ context.Context, _ ...interface{}) error {
+		OnExit(func(_ context.Context, _ ...any) error {
 			onExitStateAfired = true
 			return nil
 		})
@@ -497,7 +497,7 @@ func TestStateMachine_Fire_TransitionWhenParameterizedGuardTrue(t *testing.T) {
 	sm := NewStateMachine(stateA)
 	sm.SetTriggerParameters(triggerX, reflect.TypeOf(0))
 	sm.Configure(stateA).
-		Permit(triggerX, stateB, func(_ context.Context, args ...interface{}) bool {
+		Permit(triggerX, stateB, func(_ context.Context, args ...any) bool {
 			return args[0].(int) == 2
 		})
 
@@ -510,7 +510,7 @@ func TestStateMachine_Fire_ErrorWhenParameterizedGuardFalse(t *testing.T) {
 	sm := NewStateMachine(stateA)
 	sm.SetTriggerParameters(triggerX, reflect.TypeOf(0))
 	sm.Configure(stateA).
-		Permit(triggerX, stateB, func(_ context.Context, args ...interface{}) bool {
+		Permit(triggerX, stateB, func(_ context.Context, args ...any) bool {
 			return args[0].(int) == 3
 		})
 
@@ -523,9 +523,9 @@ func TestStateMachine_Fire_TransitionWhenBothParameterizedGuardClausesTrue(t *te
 	sm := NewStateMachine(stateA)
 	sm.SetTriggerParameters(triggerX, reflect.TypeOf(0))
 	sm.Configure(stateA).
-		Permit(triggerX, stateB, func(_ context.Context, args ...interface{}) bool {
+		Permit(triggerX, stateB, func(_ context.Context, args ...any) bool {
 			return args[0].(int) == 2
-		}, func(_ context.Context, args ...interface{}) bool {
+		}, func(_ context.Context, args ...any) bool {
 			return args[0].(int) != 3
 		})
 
@@ -538,7 +538,7 @@ func TestStateMachine_Fire_TransitionWhenGuardReturnsTrueOnTriggerWithMultiplePa
 	sm := NewStateMachine(stateA)
 	sm.SetTriggerParameters(triggerX, reflect.TypeOf(""), reflect.TypeOf(0))
 	sm.Configure(stateA).
-		Permit(triggerX, stateB, func(_ context.Context, args ...interface{}) bool {
+		Permit(triggerX, stateB, func(_ context.Context, args ...any) bool {
 			return args[0].(string) == "3" && args[1].(int) == 2
 		})
 
@@ -551,18 +551,18 @@ func TestStateMachine_Fire_TransitionWhenPermitDyanmicIfHasMultipleExclusiveGuar
 	sm := NewStateMachine(stateA)
 	sm.SetTriggerParameters(triggerX, reflect.TypeOf(0))
 	sm.Configure(stateA).
-		PermitDynamic(triggerX, func(_ context.Context, args ...interface{}) (State, error) {
+		PermitDynamic(triggerX, func(_ context.Context, args ...any) (State, error) {
 			if args[0].(int) == 3 {
 				return stateB, nil
 			}
 			return stateC, nil
-		}, func(_ context.Context, args ...interface{}) bool { return args[0].(int) == 3 || args[0].(int) == 5 }).
-		PermitDynamic(triggerX, func(_ context.Context, args ...interface{}) (State, error) {
+		}, func(_ context.Context, args ...any) bool { return args[0].(int) == 3 || args[0].(int) == 5 }).
+		PermitDynamic(triggerX, func(_ context.Context, args ...any) (State, error) {
 			if args[0].(int) == 2 {
 				return stateC, nil
 			}
 			return stateD, nil
-		}, func(_ context.Context, args ...interface{}) bool { return args[0].(int) == 2 || args[0].(int) == 4 })
+		}, func(_ context.Context, args ...any) bool { return args[0].(int) == 2 || args[0].(int) == 4 })
 
 	sm.Fire(triggerX, 3)
 
@@ -572,7 +572,7 @@ func TestStateMachine_Fire_TransitionWhenPermitDyanmicIfHasMultipleExclusiveGuar
 func TestStateMachine_Fire_PermitDyanmic_Error(t *testing.T) {
 	sm := NewStateMachine(stateA)
 	sm.Configure(stateA).
-		PermitDynamic(triggerX, func(_ context.Context, _ ...interface{}) (State, error) {
+		PermitDynamic(triggerX, func(_ context.Context, _ ...any) (State, error) {
 			return nil, errors.New("")
 		})
 
@@ -584,18 +584,18 @@ func TestStateMachine_Fire_PanicsWhenPermitDyanmicIfHasMultipleNonExclusiveGuard
 	sm := NewStateMachine(stateA)
 	sm.SetTriggerParameters(triggerX, reflect.TypeOf(0))
 	sm.Configure(stateA).
-		PermitDynamic(triggerX, func(_ context.Context, args ...interface{}) (State, error) {
+		PermitDynamic(triggerX, func(_ context.Context, args ...any) (State, error) {
 			if args[0].(int) == 4 {
 				return stateB, nil
 			}
 			return stateC, nil
-		}, func(_ context.Context, args ...interface{}) bool { return args[0].(int)%2 == 0 }).
-		PermitDynamic(triggerX, func(_ context.Context, args ...interface{}) (State, error) {
+		}, func(_ context.Context, args ...any) bool { return args[0].(int)%2 == 0 }).
+		PermitDynamic(triggerX, func(_ context.Context, args ...any) (State, error) {
 			if args[0].(int) == 2 {
 				return stateC, nil
 			}
 			return stateD, nil
-		}, func(_ context.Context, args ...interface{}) bool { return args[0].(int) == 2 })
+		}, func(_ context.Context, args ...any) bool { return args[0].(int) == 2 })
 
 	assert.Panics(t, func() { sm.Fire(triggerX, 2) })
 }
@@ -604,13 +604,13 @@ func TestStateMachine_Fire_TransitionWhenPermitIfHasMultipleExclusiveGuardsWithS
 	sm := NewStateMachine(stateB)
 	sm.SetTriggerParameters(triggerX, reflect.TypeOf(0))
 	sm.Configure(stateA).
-		Permit(triggerX, stateD, func(_ context.Context, args ...interface{}) bool {
+		Permit(triggerX, stateD, func(_ context.Context, args ...any) bool {
 			return args[0].(int) == 3
 		})
 
 	sm.Configure(stateB).
 		SubstateOf(stateA).
-		Permit(triggerX, stateC, func(_ context.Context, args ...interface{}) bool {
+		Permit(triggerX, stateC, func(_ context.Context, args ...any) bool {
 			return args[0].(int) == 2
 		})
 
@@ -623,13 +623,13 @@ func TestStateMachine_Fire_TransitionWhenPermitIfHasMultipleExclusiveGuardsWithS
 	sm := NewStateMachine(stateB)
 	sm.SetTriggerParameters(triggerX, reflect.TypeOf(0))
 	sm.Configure(stateA).
-		Permit(triggerX, stateD, func(_ context.Context, args ...interface{}) bool {
+		Permit(triggerX, stateD, func(_ context.Context, args ...any) bool {
 			return args[0].(int) == 3
 		})
 
 	sm.Configure(stateB).
 		SubstateOf(stateA).
-		Permit(triggerX, stateC, func(_ context.Context, args ...interface{}) bool {
+		Permit(triggerX, stateC, func(_ context.Context, args ...any) bool {
 			return args[0].(int) == 2
 		})
 
@@ -642,11 +642,11 @@ func TestStateMachine_Fire_TransitionToSuperstateDoesNotExitSuperstate(t *testin
 	sm := NewStateMachine(stateB)
 	var superExit, superEntry, subExit bool
 	sm.Configure(stateA).
-		OnEntry(func(_ context.Context, _ ...interface{}) error {
+		OnEntry(func(_ context.Context, _ ...any) error {
 			superEntry = true
 			return nil
 		}).
-		OnExit(func(_ context.Context, _ ...interface{}) error {
+		OnExit(func(_ context.Context, _ ...any) error {
 			superExit = true
 			return nil
 		})
@@ -654,7 +654,7 @@ func TestStateMachine_Fire_TransitionToSuperstateDoesNotExitSuperstate(t *testin
 	sm.Configure(stateB).
 		SubstateOf(stateA).
 		Permit(triggerY, stateA).
-		OnExit(func(_ context.Context, _ ...interface{}) error {
+		OnExit(func(_ context.Context, _ ...any) error {
 			subExit = true
 			return nil
 		})
@@ -671,22 +671,22 @@ func TestStateMachine_Fire_OnExitFiresOnlyOnceReentrySubstate(t *testing.T) {
 	var exitB, exitA, entryB, entryA int
 	sm.Configure(stateA).
 		SubstateOf(stateB).
-		OnEntry(func(_ context.Context, _ ...interface{}) error {
+		OnEntry(func(_ context.Context, _ ...any) error {
 			entryA += 1
 			return nil
 		}).
 		PermitReentry(triggerX).
-		OnExit(func(_ context.Context, _ ...interface{}) error {
+		OnExit(func(_ context.Context, _ ...any) error {
 			exitA += 1
 			return nil
 		})
 
 	sm.Configure(stateB).
-		OnEntry(func(_ context.Context, _ ...interface{}) error {
+		OnEntry(func(_ context.Context, _ ...any) error {
 			entryB += 1
 			return nil
 		}).
-		OnExit(func(_ context.Context, _ ...interface{}) error {
+		OnExit(func(_ context.Context, _ ...any) error {
 			exitB += 1
 			return nil
 		})
@@ -895,11 +895,11 @@ func TestStateMachine_Activate_Transitioning(t *testing.T) {
 			actualOrdering = append(actualOrdering, "DeactivatedA")
 			return nil
 		}).
-		OnEntry(func(_ context.Context, _ ...interface{}) error {
+		OnEntry(func(_ context.Context, _ ...any) error {
 			actualOrdering = append(actualOrdering, "EnteredA")
 			return nil
 		}).
-		OnExit(func(_ context.Context, _ ...interface{}) error {
+		OnExit(func(_ context.Context, _ ...any) error {
 			actualOrdering = append(actualOrdering, "ExitedA")
 			return nil
 		}).
@@ -914,11 +914,11 @@ func TestStateMachine_Activate_Transitioning(t *testing.T) {
 			actualOrdering = append(actualOrdering, "DeactivatedB")
 			return nil
 		}).
-		OnEntry(func(_ context.Context, _ ...interface{}) error {
+		OnEntry(func(_ context.Context, _ ...any) error {
 			actualOrdering = append(actualOrdering, "EnteredB")
 			return nil
 		}).
-		OnExit(func(_ context.Context, _ ...interface{}) error {
+		OnExit(func(_ context.Context, _ ...any) error {
 			actualOrdering = append(actualOrdering, "ExitedB")
 			return nil
 		}).
@@ -945,23 +945,23 @@ func TestStateMachine_Fire_ImmediateEntryAProcessedBeforeEnterB(t *testing.T) {
 	expectedOrdering := []string{"ExitA", "ExitB", "EnterA", "EnterB"}
 
 	sm.Configure(stateA).
-		OnEntry(func(_ context.Context, _ ...interface{}) error {
+		OnEntry(func(_ context.Context, _ ...any) error {
 			actualOrdering = append(actualOrdering, "EnterA")
 			return nil
 		}).
-		OnExit(func(_ context.Context, _ ...interface{}) error {
+		OnExit(func(_ context.Context, _ ...any) error {
 			actualOrdering = append(actualOrdering, "ExitA")
 			return nil
 		}).
 		Permit(triggerX, stateB)
 
 	sm.Configure(stateB).
-		OnEntry(func(_ context.Context, _ ...interface{}) error {
+		OnEntry(func(_ context.Context, _ ...any) error {
 			sm.Fire(triggerY)
 			actualOrdering = append(actualOrdering, "EnterB")
 			return nil
 		}).
-		OnExit(func(_ context.Context, _ ...interface{}) error {
+		OnExit(func(_ context.Context, _ ...any) error {
 			actualOrdering = append(actualOrdering, "ExitB")
 			return nil
 		}).
@@ -979,23 +979,23 @@ func TestStateMachine_Fire_QueuedEntryAProcessedBeforeEnterB(t *testing.T) {
 	expectedOrdering := []string{"ExitA", "EnterB", "ExitB", "EnterA"}
 
 	sm.Configure(stateA).
-		OnEntry(func(_ context.Context, _ ...interface{}) error {
+		OnEntry(func(_ context.Context, _ ...any) error {
 			actualOrdering = append(actualOrdering, "EnterA")
 			return nil
 		}).
-		OnExit(func(_ context.Context, _ ...interface{}) error {
+		OnExit(func(_ context.Context, _ ...any) error {
 			actualOrdering = append(actualOrdering, "ExitA")
 			return nil
 		}).
 		Permit(triggerX, stateB)
 
 	sm.Configure(stateB).
-		OnEntry(func(_ context.Context, _ ...interface{}) error {
+		OnEntry(func(_ context.Context, _ ...any) error {
 			sm.Fire(triggerY)
 			actualOrdering = append(actualOrdering, "EnterB")
 			return nil
 		}).
-		OnExit(func(_ context.Context, _ ...interface{}) error {
+		OnExit(func(_ context.Context, _ ...any) error {
 			actualOrdering = append(actualOrdering, "ExitB")
 			return nil
 		}).
@@ -1013,7 +1013,7 @@ func TestStateMachine_Fire_QueuedEntryAsyncFire(t *testing.T) {
 		Permit(triggerX, stateB)
 
 	sm.Configure(stateB).
-		OnEntry(func(_ context.Context, _ ...interface{}) error {
+		OnEntry(func(_ context.Context, _ ...any) error {
 			go sm.Fire(triggerY)
 			go sm.Fire(triggerY)
 			return nil
@@ -1029,13 +1029,13 @@ func TestStateMachine_Fire_Race(t *testing.T) {
 	var actualOrdering []string
 	var mu sync.Mutex
 	sm.Configure(stateA).
-		OnEntry(func(_ context.Context, _ ...interface{}) error {
+		OnEntry(func(_ context.Context, _ ...any) error {
 			mu.Lock()
 			actualOrdering = append(actualOrdering, "EnterA")
 			mu.Unlock()
 			return nil
 		}).
-		OnExit(func(_ context.Context, _ ...interface{}) error {
+		OnExit(func(_ context.Context, _ ...any) error {
 			mu.Lock()
 			actualOrdering = append(actualOrdering, "ExitA")
 			mu.Unlock()
@@ -1044,14 +1044,14 @@ func TestStateMachine_Fire_Race(t *testing.T) {
 		Permit(triggerX, stateB)
 
 	sm.Configure(stateB).
-		OnEntry(func(_ context.Context, _ ...interface{}) error {
+		OnEntry(func(_ context.Context, _ ...any) error {
 			sm.Fire(triggerY)
 			mu.Lock()
 			actualOrdering = append(actualOrdering, "EnterB")
 			mu.Unlock()
 			return nil
 		}).
-		OnExit(func(_ context.Context, _ ...interface{}) error {
+		OnExit(func(_ context.Context, _ ...any) error {
 			mu.Lock()
 			actualOrdering = append(actualOrdering, "ExitB")
 			mu.Unlock()
@@ -1080,11 +1080,11 @@ func TestStateMachine_Fire_Queued_ErrorExit(t *testing.T) {
 		Permit(triggerX, stateB)
 
 	sm.Configure(stateB).
-		OnEntry(func(_ context.Context, _ ...interface{}) error {
+		OnEntry(func(_ context.Context, _ ...any) error {
 			sm.Fire(triggerY)
 			return nil
 		}).
-		OnExit(func(_ context.Context, _ ...interface{}) error {
+		OnExit(func(_ context.Context, _ ...any) error {
 			return errors.New("")
 		}).
 		Permit(triggerY, stateA)
@@ -1098,13 +1098,13 @@ func TestStateMachine_Fire_Queued_ErrorEnter(t *testing.T) {
 	sm := NewStateMachineWithMode(stateA, FiringQueued)
 
 	sm.Configure(stateA).
-		OnEntry(func(_ context.Context, _ ...interface{}) error {
+		OnEntry(func(_ context.Context, _ ...any) error {
 			return errors.New("")
 		}).
 		Permit(triggerX, stateB)
 
 	sm.Configure(stateB).
-		OnEntry(func(_ context.Context, _ ...interface{}) error {
+		OnEntry(func(_ context.Context, _ ...any) error {
 			sm.Fire(triggerY)
 			return nil
 		}).
@@ -1118,7 +1118,7 @@ func TestStateMachine_Fire_Queued_ErrorEnter(t *testing.T) {
 func TestStateMachine_InternalTransition_StayInSameStateOneState(t *testing.T) {
 	sm := NewStateMachine(stateA)
 	sm.Configure(stateB).
-		InternalTransition(triggerX, func(_ context.Context, _ ...interface{}) error {
+		InternalTransition(triggerX, func(_ context.Context, _ ...any) error {
 			return nil
 		})
 
@@ -1130,14 +1130,14 @@ func TestStateMachine_InternalTransition_HandledOnlyOnceInSuper(t *testing.T) {
 	sm := NewStateMachine(stateA)
 	handledIn := stateC
 	sm.Configure(stateA).
-		InternalTransition(triggerX, func(_ context.Context, _ ...interface{}) error {
+		InternalTransition(triggerX, func(_ context.Context, _ ...any) error {
 			handledIn = stateA
 			return nil
 		})
 
 	sm.Configure(stateB).
 		SubstateOf(stateA).
-		InternalTransition(triggerX, func(_ context.Context, _ ...interface{}) error {
+		InternalTransition(triggerX, func(_ context.Context, _ ...any) error {
 			handledIn = stateB
 			return nil
 		})
@@ -1150,14 +1150,14 @@ func TestStateMachine_InternalTransition_HandledOnlyOnceInSub(t *testing.T) {
 	sm := NewStateMachine(stateB)
 	handledIn := stateC
 	sm.Configure(stateA).
-		InternalTransition(triggerX, func(_ context.Context, _ ...interface{}) error {
+		InternalTransition(triggerX, func(_ context.Context, _ ...any) error {
 			handledIn = stateA
 			return nil
 		})
 
 	sm.Configure(stateB).
 		SubstateOf(stateA).
-		InternalTransition(triggerX, func(_ context.Context, _ ...interface{}) error {
+		InternalTransition(triggerX, func(_ context.Context, _ ...any) error {
 			handledIn = stateB
 			return nil
 		})
@@ -1210,21 +1210,21 @@ func TestStateMachine_InitialTransition_Ordering(t *testing.T) {
 
 	sm.Configure(stateA).
 		Permit(triggerX, stateB).
-		OnExit(func(c context.Context, i ...interface{}) error {
+		OnExit(func(c context.Context, i ...any) error {
 			actualOrdering = append(actualOrdering, "ExitA")
 			return nil
 		})
 
 	sm.Configure(stateB).
 		InitialTransition(stateC).
-		OnEntry(func(c context.Context, i ...interface{}) error {
+		OnEntry(func(c context.Context, i ...any) error {
 			actualOrdering = append(actualOrdering, "EnterB")
 			return nil
 		})
 
 	sm.Configure(stateC).
 		SubstateOf(stateB).
-		OnEntry(func(c context.Context, i ...interface{}) error {
+		OnEntry(func(c context.Context, i ...any) error {
 			actualOrdering = append(actualOrdering, "EnterC")
 			return nil
 		})
@@ -1331,7 +1331,7 @@ func TestStateMachine_Firing_Queued(t *testing.T) {
 		Permit(triggerX, stateB)
 
 	sm.Configure(stateB).
-		OnEntry(func(ctx context.Context, i ...interface{}) error {
+		OnEntry(func(ctx context.Context, i ...any) error {
 			assert.True(t, sm.Firing())
 			return nil
 		})
@@ -1347,7 +1347,7 @@ func TestStateMachine_Firing_Immediate(t *testing.T) {
 		Permit(triggerX, stateB)
 
 	sm.Configure(stateB).
-		OnEntry(func(ctx context.Context, i ...interface{}) error {
+		OnEntry(func(ctx context.Context, i ...any) error {
 			assert.True(t, sm.Firing())
 			return nil
 		})
@@ -1361,7 +1361,7 @@ func TestStateMachine_Firing_Concurrent(t *testing.T) {
 
 	sm.Configure(stateA).
 		PermitReentry(triggerX).
-		OnEntry(func(ctx context.Context, i ...interface{}) error {
+		OnEntry(func(ctx context.Context, i ...any) error {
 			assert.True(t, sm.Firing())
 			return nil
 		})

--- a/states.go
+++ b/states.go
@@ -11,7 +11,7 @@ type actionBehaviour struct {
 	Trigger     *Trigger
 }
 
-func (a actionBehaviour) Execute(ctx context.Context, transition Transition, args ...interface{}) (err error) {
+func (a actionBehaviour) Execute(ctx context.Context, transition Transition, args ...any) (err error) {
 	if a.Trigger == nil || *a.Trigger == transition.Trigger {
 		ctx = withTransition(ctx, transition)
 		err = a.Action(ctx, args...)
@@ -57,12 +57,12 @@ func (sr *stateRepresentation) state() State {
 	return sr.State
 }
 
-func (sr *stateRepresentation) CanHandle(ctx context.Context, trigger Trigger, args ...interface{}) (ok bool) {
+func (sr *stateRepresentation) CanHandle(ctx context.Context, trigger Trigger, args ...any) (ok bool) {
 	_, ok = sr.FindHandler(ctx, trigger, args...)
 	return
 }
 
-func (sr *stateRepresentation) FindHandler(ctx context.Context, trigger Trigger, args ...interface{}) (handler triggerBehaviourResult, ok bool) {
+func (sr *stateRepresentation) FindHandler(ctx context.Context, trigger Trigger, args ...any) (handler triggerBehaviourResult, ok bool) {
 	handler, ok = sr.findHandler(ctx, trigger, args...)
 	if ok || sr.Superstate == nil {
 		return
@@ -71,7 +71,7 @@ func (sr *stateRepresentation) FindHandler(ctx context.Context, trigger Trigger,
 	return
 }
 
-func (sr *stateRepresentation) findHandler(ctx context.Context, trigger Trigger, args ...interface{}) (result triggerBehaviourResult, ok bool) {
+func (sr *stateRepresentation) findHandler(ctx context.Context, trigger Trigger, args ...any) (result triggerBehaviourResult, ok bool) {
 	var (
 		possibleBehaviours []triggerBehaviour
 	)
@@ -124,7 +124,7 @@ func (sr *stateRepresentation) Deactivate(ctx context.Context) error {
 	return nil
 }
 
-func (sr *stateRepresentation) Enter(ctx context.Context, transition Transition, args ...interface{}) error {
+func (sr *stateRepresentation) Enter(ctx context.Context, transition Transition, args ...any) error {
 	if transition.IsReentry() {
 		return sr.executeEntryActions(ctx, transition, args...)
 	}
@@ -139,7 +139,7 @@ func (sr *stateRepresentation) Enter(ctx context.Context, transition Transition,
 	return sr.executeEntryActions(ctx, transition, args...)
 }
 
-func (sr *stateRepresentation) Exit(ctx context.Context, transition Transition, args ...interface{}) (err error) {
+func (sr *stateRepresentation) Exit(ctx context.Context, transition Transition, args ...any) (err error) {
 	isReentry := transition.IsReentry()
 	if !isReentry && sr.IncludeState(transition.Destination) {
 		return
@@ -162,7 +162,7 @@ func (sr *stateRepresentation) Exit(ctx context.Context, transition Transition, 
 	return
 }
 
-func (sr *stateRepresentation) InternalAction(ctx context.Context, transition Transition, args ...interface{}) error {
+func (sr *stateRepresentation) InternalAction(ctx context.Context, transition Transition, args ...any) error {
 	var internalTransition *internalTriggerBehaviour
 	var stateRep *stateRepresentation = sr
 	for stateRep != nil {
@@ -209,7 +209,7 @@ func (sr *stateRepresentation) AddTriggerBehaviour(tb triggerBehaviour) {
 
 }
 
-func (sr *stateRepresentation) PermittedTriggers(ctx context.Context, args ...interface{}) (triggers []Trigger) {
+func (sr *stateRepresentation) PermittedTriggers(ctx context.Context, args ...any) (triggers []Trigger) {
 	for key, value := range sr.TriggerBehaviours {
 		for _, tb := range value {
 			if len(tb.UnmetGuardConditions(ctx, args...)) == 0 {
@@ -254,7 +254,7 @@ func (sr *stateRepresentation) executeDeactivationActions(ctx context.Context) e
 	return nil
 }
 
-func (sr *stateRepresentation) executeEntryActions(ctx context.Context, transition Transition, args ...interface{}) error {
+func (sr *stateRepresentation) executeEntryActions(ctx context.Context, transition Transition, args ...any) error {
 	for _, a := range sr.EntryActions {
 		if err := a.Execute(ctx, transition, args...); err != nil {
 			return err
@@ -263,7 +263,7 @@ func (sr *stateRepresentation) executeEntryActions(ctx context.Context, transiti
 	return nil
 }
 
-func (sr *stateRepresentation) executeExitActions(ctx context.Context, transition Transition, args ...interface{}) error {
+func (sr *stateRepresentation) executeExitActions(ctx context.Context, transition Transition, args ...any) error {
 	for _, a := range sr.ExitActions {
 		if err := a.Execute(ctx, transition, args...); err != nil {
 			return err

--- a/states_test.go
+++ b/states_test.go
@@ -80,9 +80,9 @@ func Test_stateRepresentation_CanHandle_TransitionUnmetGuardConditions_TriggerCa
 	sr := newstateRepresentation(stateB)
 	sr.AddTriggerBehaviour(&transitioningTriggerBehaviour{baseTriggerBehaviour: baseTriggerBehaviour{
 		Trigger: triggerX,
-		Guard: newtransitionGuard(func(_ context.Context, _ ...interface{}) bool {
+		Guard: newtransitionGuard(func(_ context.Context, _ ...any) bool {
 			return true
-		}, func(_ context.Context, _ ...interface{}) bool {
+		}, func(_ context.Context, _ ...any) bool {
 			return false
 		}),
 	}, Destination: stateC})
@@ -93,9 +93,9 @@ func Test_stateRepresentation_CanHandle_TransitionGuardConditionsMet_TriggerCanB
 	sr := newstateRepresentation(stateB)
 	sr.AddTriggerBehaviour(&transitioningTriggerBehaviour{baseTriggerBehaviour: baseTriggerBehaviour{
 		Trigger: triggerX,
-		Guard: newtransitionGuard(func(_ context.Context, _ ...interface{}) bool {
+		Guard: newtransitionGuard(func(_ context.Context, _ ...any) bool {
 			return true
-		}, func(_ context.Context, _ ...interface{}) bool {
+		}, func(_ context.Context, _ ...any) bool {
 			return true
 		}),
 	}, Destination: stateC})
@@ -106,9 +106,9 @@ func Test_stateRepresentation_FindHandler_TransitionExistAndSuperstateUnmetGuard
 	super, sub := createSuperSubstatePair()
 	super.AddTriggerBehaviour(&transitioningTriggerBehaviour{baseTriggerBehaviour: baseTriggerBehaviour{
 		Trigger: triggerX,
-		Guard: newtransitionGuard(func(_ context.Context, _ ...interface{}) bool {
+		Guard: newtransitionGuard(func(_ context.Context, _ ...any) bool {
 			return true
-		}, func(_ context.Context, _ ...interface{}) bool {
+		}, func(_ context.Context, _ ...any) bool {
 			return false
 		}),
 	}, Destination: stateC})
@@ -124,9 +124,9 @@ func Test_stateRepresentation_FindHandler_TransitionExistSuperstateMetGuardCondi
 	super, sub := createSuperSubstatePair()
 	super.AddTriggerBehaviour(&transitioningTriggerBehaviour{baseTriggerBehaviour: baseTriggerBehaviour{
 		Trigger: triggerX,
-		Guard: newtransitionGuard(func(_ context.Context, _ ...interface{}) bool {
+		Guard: newtransitionGuard(func(_ context.Context, _ ...any) bool {
 			return true
-		}, func(_ context.Context, _ ...interface{}) bool {
+		}, func(_ context.Context, _ ...any) bool {
 			return true
 		}),
 	}, Destination: stateC})
@@ -144,7 +144,7 @@ func Test_stateRepresentation_Enter_EnteringActionsExecuted(t *testing.T) {
 	transition := Transition{Source: stateA, Destination: stateB, Trigger: triggerX}
 	var actualTransition Transition
 	sr.EntryActions = append(sr.EntryActions, actionBehaviour{
-		Action: func(_ context.Context, _ ...interface{}) error {
+		Action: func(_ context.Context, _ ...any) error {
 			actualTransition = transition
 			return nil
 		},
@@ -159,7 +159,7 @@ func Test_stateRepresentation_Enter_EnteringActionsExecuted_Error(t *testing.T) 
 	transition := Transition{Source: stateA, Destination: stateB, Trigger: triggerX}
 	var actualTransition Transition
 	sr.EntryActions = append(sr.EntryActions, actionBehaviour{
-		Action: func(_ context.Context, _ ...interface{}) error {
+		Action: func(_ context.Context, _ ...any) error {
 			return errors.New("")
 		},
 	})
@@ -173,7 +173,7 @@ func Test_stateRepresentation_Enter_LeavingActionsNotExecuted(t *testing.T) {
 	transition := Transition{Source: stateA, Destination: stateB, Trigger: triggerX}
 	var actualTransition Transition
 	sr.ExitActions = append(sr.ExitActions, actionBehaviour{
-		Action: func(_ context.Context, _ ...interface{}) error {
+		Action: func(_ context.Context, _ ...any) error {
 			actualTransition = transition
 			return nil
 		},
@@ -186,7 +186,7 @@ func Test_stateRepresentation_Enter_FromSubToSuperstate_SubstateEntryActionsExec
 	super, sub := createSuperSubstatePair()
 	executed := false
 	sub.EntryActions = append(sub.EntryActions, actionBehaviour{
-		Action: func(_ context.Context, _ ...interface{}) error {
+		Action: func(_ context.Context, _ ...any) error {
 			executed = true
 			return nil
 		},
@@ -200,7 +200,7 @@ func Test_stateRepresentation_Enter_SuperFromSubstate_SuperEntryActionsNotExecut
 	super, sub := createSuperSubstatePair()
 	executed := false
 	super.EntryActions = append(super.EntryActions, actionBehaviour{
-		Action: func(_ context.Context, _ ...interface{}) error {
+		Action: func(_ context.Context, _ ...any) error {
 			executed = true
 			return nil
 		},
@@ -214,7 +214,7 @@ func Test_stateRepresentation_Enter_Substate_SuperEntryActionsExecuted(t *testin
 	super, sub := createSuperSubstatePair()
 	executed := false
 	super.EntryActions = append(super.EntryActions, actionBehaviour{
-		Action: func(_ context.Context, _ ...interface{}) error {
+		Action: func(_ context.Context, _ ...any) error {
 			executed = true
 			return nil
 		},
@@ -228,13 +228,13 @@ func Test_stateRepresentation_Enter_ActionsExecuteInOrder(t *testing.T) {
 	var actual []int
 	sr := newstateRepresentation(stateB)
 	sr.EntryActions = append(sr.EntryActions, actionBehaviour{
-		Action: func(_ context.Context, _ ...interface{}) error {
+		Action: func(_ context.Context, _ ...any) error {
 			actual = append(actual, 0)
 			return nil
 		},
 	})
 	sr.EntryActions = append(sr.EntryActions, actionBehaviour{
-		Action: func(_ context.Context, _ ...interface{}) error {
+		Action: func(_ context.Context, _ ...any) error {
 			actual = append(actual, 1)
 			return nil
 		},
@@ -250,14 +250,14 @@ func Test_stateRepresentation_Enter_Substate_SuperstateEntryActionsExecuteBefore
 	super, sub := createSuperSubstatePair()
 	var order, subOrder, superOrder int
 	super.EntryActions = append(super.EntryActions, actionBehaviour{
-		Action: func(_ context.Context, _ ...interface{}) error {
+		Action: func(_ context.Context, _ ...any) error {
 			order += 1
 			superOrder = order
 			return nil
 		},
 	})
 	sub.EntryActions = append(sub.EntryActions, actionBehaviour{
-		Action: func(_ context.Context, _ ...interface{}) error {
+		Action: func(_ context.Context, _ ...any) error {
 			order += 1
 			subOrder = order
 			return nil
@@ -273,7 +273,7 @@ func Test_stateRepresentation_Exit_EnteringActionsNotExecuted(t *testing.T) {
 	transition := Transition{Source: stateA, Destination: stateB, Trigger: triggerX}
 	var actualTransition Transition
 	sr.EntryActions = append(sr.EntryActions, actionBehaviour{
-		Action: func(_ context.Context, _ ...interface{}) error {
+		Action: func(_ context.Context, _ ...any) error {
 			actualTransition = transition
 			return nil
 		},
@@ -287,7 +287,7 @@ func Test_stateRepresentation_Exit_LeavingActionsExecuted(t *testing.T) {
 	transition := Transition{Source: stateA, Destination: stateB, Trigger: triggerX}
 	var actualTransition Transition
 	sr.ExitActions = append(sr.ExitActions, actionBehaviour{
-		Action: func(_ context.Context, _ ...interface{}) error {
+		Action: func(_ context.Context, _ ...any) error {
 			actualTransition = transition
 			return nil
 		},
@@ -302,7 +302,7 @@ func Test_stateRepresentation_Exit_LeavingActionsExecuted_Error(t *testing.T) {
 	transition := Transition{Source: stateA, Destination: stateB, Trigger: triggerX}
 	var actualTransition Transition
 	sr.ExitActions = append(sr.ExitActions, actionBehaviour{
-		Action: func(_ context.Context, _ ...interface{}) error {
+		Action: func(_ context.Context, _ ...any) error {
 			return errors.New("")
 		},
 	})
@@ -315,7 +315,7 @@ func Test_stateRepresentation_Exit_FromSubToSuperstate_SubstateExitActionsExecut
 	super, sub := createSuperSubstatePair()
 	executed := false
 	sub.ExitActions = append(sub.ExitActions, actionBehaviour{
-		Action: func(_ context.Context, _ ...interface{}) error {
+		Action: func(_ context.Context, _ ...any) error {
 			executed = true
 			return nil
 		},
@@ -332,7 +332,7 @@ func Test_stateRepresentation_Exit_FromSubToOther_SuperstateExitActionsExecuted(
 	supersuper.Superstate = newstateRepresentation(stateD)
 	executed := false
 	super.ExitActions = append(super.ExitActions, actionBehaviour{
-		Action: func(_ context.Context, _ ...interface{}) error {
+		Action: func(_ context.Context, _ ...any) error {
 			executed = true
 			return nil
 		},
@@ -346,7 +346,7 @@ func Test_stateRepresentation_Exit_FromSuperToSubstate_SuperExitActionsNotExecut
 	super, sub := createSuperSubstatePair()
 	executed := false
 	super.ExitActions = append(super.ExitActions, actionBehaviour{
-		Action: func(_ context.Context, _ ...interface{}) error {
+		Action: func(_ context.Context, _ ...any) error {
 			executed = true
 			return nil
 		},
@@ -360,7 +360,7 @@ func Test_stateRepresentation_Exit_Substate_SuperExitActionsExecuted(t *testing.
 	super, sub := createSuperSubstatePair()
 	executed := false
 	super.ExitActions = append(super.ExitActions, actionBehaviour{
-		Action: func(_ context.Context, _ ...interface{}) error {
+		Action: func(_ context.Context, _ ...any) error {
 			executed = true
 			return nil
 		},
@@ -374,13 +374,13 @@ func Test_stateRepresentation_Exit_ActionsExecuteInOrder(t *testing.T) {
 	var actual []int
 	sr := newstateRepresentation(stateB)
 	sr.ExitActions = append(sr.ExitActions, actionBehaviour{
-		Action: func(_ context.Context, _ ...interface{}) error {
+		Action: func(_ context.Context, _ ...any) error {
 			actual = append(actual, 0)
 			return nil
 		},
 	})
 	sr.ExitActions = append(sr.ExitActions, actionBehaviour{
-		Action: func(_ context.Context, _ ...interface{}) error {
+		Action: func(_ context.Context, _ ...any) error {
 			actual = append(actual, 1)
 			return nil
 		},
@@ -396,14 +396,14 @@ func Test_stateRepresentation_Exit_Substate_SubstateEntryActionsExecuteBeforeSup
 	super, sub := createSuperSubstatePair()
 	var order, subOrder, superOrder int
 	super.ExitActions = append(super.ExitActions, actionBehaviour{
-		Action: func(_ context.Context, _ ...interface{}) error {
+		Action: func(_ context.Context, _ ...any) error {
 			order += 1
 			superOrder = order
 			return nil
 		},
 	})
 	sub.ExitActions = append(sub.ExitActions, actionBehaviour{
-		Action: func(_ context.Context, _ ...interface{}) error {
+		Action: func(_ context.Context, _ ...any) error {
 			order += 1
 			subOrder = order
 			return nil

--- a/triggers.go
+++ b/triggers.go
@@ -12,7 +12,7 @@ type invocationInfo struct {
 	Method string
 }
 
-func newinvocationInfo(method interface{}) invocationInfo {
+func newinvocationInfo(method any) invocationInfo {
 	funcName := runtime.FuncForPC(reflect.ValueOf(method).Pointer()).Name()
 	nameParts := strings.Split(funcName, ".")
 	var name string
@@ -52,7 +52,7 @@ func newtransitionGuard(guards ...GuardFunc) transitionGuard {
 }
 
 // GuardConditionsMet is true if all of the guard functions return true.
-func (t transitionGuard) GuardConditionMet(ctx context.Context, args ...interface{}) bool {
+func (t transitionGuard) GuardConditionMet(ctx context.Context, args ...any) bool {
 	for _, guard := range t.Guards {
 		if !guard.Guard(ctx, args...) {
 			return false
@@ -61,7 +61,7 @@ func (t transitionGuard) GuardConditionMet(ctx context.Context, args ...interfac
 	return true
 }
 
-func (t transitionGuard) UnmetGuardConditions(ctx context.Context, args ...interface{}) []string {
+func (t transitionGuard) UnmetGuardConditions(ctx context.Context, args ...any) []string {
 	unmet := make([]string, 0, len(t.Guards))
 	for _, guard := range t.Guards {
 		if !guard.Guard(ctx, args...) {
@@ -72,8 +72,8 @@ func (t transitionGuard) UnmetGuardConditions(ctx context.Context, args ...inter
 }
 
 type triggerBehaviour interface {
-	GuardConditionMet(context.Context, ...interface{}) bool
-	UnmetGuardConditions(context.Context, ...interface{}) []string
+	GuardConditionMet(context.Context, ...any) bool
+	UnmetGuardConditions(context.Context, ...any) []string
 	GetTrigger() Trigger
 }
 
@@ -86,11 +86,11 @@ func (t *baseTriggerBehaviour) GetTrigger() Trigger {
 	return t.Trigger
 }
 
-func (t *baseTriggerBehaviour) GuardConditionMet(ctx context.Context, args ...interface{}) bool {
+func (t *baseTriggerBehaviour) GuardConditionMet(ctx context.Context, args ...any) bool {
 	return t.Guard.GuardConditionMet(ctx, args...)
 }
 
-func (t *baseTriggerBehaviour) UnmetGuardConditions(ctx context.Context, args ...interface{}) []string {
+func (t *baseTriggerBehaviour) UnmetGuardConditions(ctx context.Context, args ...any) []string {
 	return t.Guard.UnmetGuardConditions(ctx, args...)
 }
 
@@ -110,7 +110,7 @@ type transitioningTriggerBehaviour struct {
 
 type dynamicTriggerBehaviour struct {
 	baseTriggerBehaviour
-	Destination func(context.Context, ...interface{}) (State, error)
+	Destination func(context.Context, ...any) (State, error)
 }
 
 type internalTriggerBehaviour struct {
@@ -118,7 +118,7 @@ type internalTriggerBehaviour struct {
 	Action ActionFunc
 }
 
-func (t *internalTriggerBehaviour) Execute(ctx context.Context, transition Transition, args ...interface{}) error {
+func (t *internalTriggerBehaviour) Execute(ctx context.Context, transition Transition, args ...any) error {
 	ctx = withTransition(ctx, transition)
 	return t.Action(ctx, args...)
 }
@@ -134,7 +134,7 @@ type triggerWithParameters struct {
 	ArgumentTypes []reflect.Type
 }
 
-func (t triggerWithParameters) validateParameters(args ...interface{}) {
+func (t triggerWithParameters) validateParameters(args ...any) {
 	if len(args) != len(t.ArgumentTypes) {
 		panic(fmt.Sprintf("stateless: Too many parameters have been supplied. Expecting '%d' but got '%d'.", len(t.ArgumentTypes), len(args)))
 	}


### PR DESCRIPTION
Using `any` instead of `interface{}` makes the code cleaner.

Command: `gofmt -w -r "interface{} -> any" .`