### PR TITLE
Update panic message for unexpected parameter count

### DIFF
--- a/triggers.go
+++ b/triggers.go
@@ -139,7 +139,7 @@ type triggerWithParameters struct {
 
 func (t triggerWithParameters) validateParameters(args ...any) {
 	if len(args) != len(t.ArgumentTypes) {
-		panic(fmt.Sprintf("stateless: Too many parameters have been supplied. Expecting '%d' but got '%d'.", len(t.ArgumentTypes), len(args)))
+		panic(fmt.Sprintf("stateless: An unexpected amount of parameters have been supplied. Expecting '%d' but got '%d'.", len(t.ArgumentTypes), len(args)))
 	}
 	for i := range t.ArgumentTypes {
 		tp := reflect.TypeOf(args[i])


### PR DESCRIPTION
Update panic message when the amount of parameters does not match expectations.

A small change, but when I triggered this panic from my application I was confused because I had defined one parameter but failed to supply it and got this:

```
Too many parameters have been supplied. Expecting '1' but got '0'
```