### PR TITLE
feat: add OnExitWith configuration method

### DIFF
--- a/config.go
+++ b/config.go
@@ -160,6 +160,16 @@ func (sc *StateConfiguration) OnExit(action ActionFunc) *StateConfiguration {
 	return sc
 }
 
+// OnExitWith specifies an action that will execute when transitioning from the configured state with a specific trigger.
+func (sc *StateConfiguration) OnExitWith(trigger Trigger, action ActionFunc) *StateConfiguration {
+	sc.sr.ExitActions = append(sc.sr.ExitActions, actionBehaviour{
+		Action:      action,
+		Description: newinvocationInfo(action),
+		Trigger:     &trigger,
+	})
+	return sc
+}
+
 // SubstateOf sets the superstate that the configured state is a substate of.
 // Substates inherit the allowed transitions of their superstate.
 // When entering directly into a substate from outside of the superstate,

--- a/example_test.go
+++ b/example_test.go
@@ -66,6 +66,10 @@ func Example() {
 
 	phoneCall.Configure(stateOnHold).
 		SubstateOf(stateConnected).
+		OnExitWith(triggerPhoneHurledAgainstWall, func(ctx context.Context, args ...any) error {
+			onWasted()
+			return nil
+		}).
 		Permit(triggerTakenOffHold, stateConnected).
 		Permit(triggerPhoneHurledAgainstWall, statePhoneDestroyed)
 
@@ -90,6 +94,7 @@ func Example() {
 	// Microphone muted!
 	// Microphone unmuted!
 	// Volume set to 11!
+	// Wasted!
 	// [Timer:] Call ended at 11:30am
 	// State is PhoneDestroyed
 
@@ -109,6 +114,10 @@ func onMute() {
 
 func onDialed(callee string) {
 	fmt.Printf("[Phone Call] placed for : [%s]\n", callee)
+}
+
+func onWasted() {
+	fmt.Println("Wasted!")
 }
 
 func startCallTimer(_ context.Context, _ ...any) error {

--- a/graph_test.go
+++ b/graph_test.go
@@ -112,6 +112,10 @@ func phoneCall() *stateless.StateMachine {
 
 	phoneCall.Configure(stateOnHold).
 		SubstateOf(stateConnected).
+		OnExitWith(triggerPhoneHurledAgainstWall, func(ctx context.Context, args ...any) error {
+			onWasted()
+			return nil
+		}).
 		Permit(triggerTakenOffHold, stateConnected).
 		Permit(triggerPhoneHurledAgainstWall, statePhoneDestroyed)
 


### PR DESCRIPTION
This PR closes #75. It adds an additional configuration method `OnExitWith` that allows setting a specific action for leaving a state with a specific trigger similar to `OnEntryFrom`.