### PR TITLE
Add ability to configure graph rendering

### DIFF
--- a/statemachine.go
+++ b/statemachine.go
@@ -64,6 +64,7 @@ func callEvents(events []TransitionFunc, ctx context.Context, transition Transit
 type StateMachine struct {
 	stateConfig            map[State]*stateRepresentation
 	triggerConfig          map[Trigger]triggerWithParameters
+	graphConfig            GraphConfiguration
 	stateAccessor          func(context.Context) (State, error)
 	stateMutator           func(context.Context, State) error
 	unhandledTriggerAction UnhandledTriggerActionFunc
@@ -226,6 +227,12 @@ func (sm *StateMachine) SetTriggerParameters(trigger Trigger, argumentTypes ...r
 		panic(fmt.Sprintf("stateless: Parameters for the trigger '%v' have already been configured.", trigger))
 	}
 	sm.triggerConfig[trigger] = config
+}
+
+// SetGraphConfiguration sets a new configuration for rendering graphs
+// using the ToGraph function.
+func (sm *StateMachine) SetGraphConfiguration(config GraphConfiguration) {
+	sm.graphConfig = config
 }
 
 // Fire see FireCtx


### PR DESCRIPTION
In my use of stateless' `ToGraph` method I have found that the graphs sometimes get confusing. Coloring some "special" triggers differently has helped me make the graphs less confusing. For some scenarios (especially ignored transitions), I can even imagine that omitting such special triggers could be useful.

This pull request adds the ability to configure the rendering of ignored, reentrant and internal transitions.

# Demo 1: Default rendering
When the new config is not set, the graph generated in `example_test.go` looks as usual:
![demo1](https://github.com/qmuntal/stateless/assets/42150522/f478cbbd-92b9-48e1-8c4c-6ec1a167f1e8)

# Demo 2: Coloring internal transitions
With `phoneCall.SetGraphConfiguration(stateless.GraphConfiguration{InternalTransitionColor: "blue"})` the internal transitions are accentuated:
![demo2](https://github.com/user-attachments/assets/0988d90e-87a2-4991-9c75-0df2061b4857)

# Demo 3: Omitting internal transitions
With `phoneCall.SetGraphConfiguration(stateless.GraphConfiguration{OmitInternalTransitions: true})` the internal transitions are omitted from the graph:
![demo3](https://github.com/qmuntal/stateless/assets/42150522/359d4869-2dd4-46fe-9bd6-c161d9cc698b)
