### PR TITLE
Reduce ToGraph memory usage

### DIFF
--- a/graph_test.go
+++ b/graph_test.go
@@ -155,3 +155,11 @@ func TestStateMachine_ToGraph(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkToGraph(b *testing.B) {
+	sm := phoneCall()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = sm.ToGraph()
+	}
+}


### PR DESCRIPTION
Improvements:

```
goos: windows
goarch: amd64
pkg: github.com/qmuntal/stateless
cpu: Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz
           │   old.txt    │            new.txt            │
           │    sec/op    │   sec/op     vs base          │
ToGraph-12   15.24µ ± 20%   15.13µ ± 6%  ~ (p=0.247 n=10)

           │   old.txt    │               new.txt                │
           │     B/op     │     B/op      vs base                │
ToGraph-12   7.188Ki ± 0%   5.569Ki ± 0%  -22.51% (p=0.000 n=10)

           │  old.txt   │              new.txt               │
           │ allocs/op  │ allocs/op   vs base                │
ToGraph-12   196.0 ± 0%   172.0 ± 0%  -12.24% (p=0.000 n=10)
```